### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.egg.papertrail</groupId>
   <artifactId>paper-trail-bot</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <name>PaperTrail</name>
   <description>A simple bot for logging all user actions</description>
   <properties>

--- a/src/main/java/org/papertrail/listeners/customlisteners/RequiredPermissionCheckListener.java
+++ b/src/main/java/org/papertrail/listeners/customlisteners/RequiredPermissionCheckListener.java
@@ -1,12 +1,12 @@
 package org.papertrail.listeners.customlisteners;
 
 import java.util.EnumMap;
-import java.util.EnumSet;
 import java.util.Map;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.SelfUser;
@@ -25,10 +25,13 @@ public class RequiredPermissionCheckListener extends ListenerAdapter {
 					
 			SelfUser botAsUser = event.getJDA().getSelfUser();
 			Role botIntegrationRole = guild.getRoleByBot(botAsUser);
+			Member botMember = guild.getMember(botAsUser);
 			
 			EmbedBuilder eb = new EmbedBuilder();
 			eb.setTitle("PaperTrail Permissions Checker");
 			eb.setDescription("Helps determine whether the required permissions are granted for PaperTrail to function properly");
+			
+			eb.addField("Bot Integration Role Specific Permission", (botIntegrationRole.hasPermission(Permission.VIEW_AUDIT_LOGS) ? "✅" : "❌")+Permission.VIEW_AUDIT_LOGS.getName(), false);
 			
 			// create a map of required permissions and set all their statuses to false
 			Map<Permission, Boolean> requiredPermissions = new EnumMap<>(Permission.class);
@@ -37,30 +40,17 @@ public class RequiredPermissionCheckListener extends ListenerAdapter {
 					Permission.MESSAGE_HISTORY, false,
 					Permission.MESSAGE_SEND, false,
 					Permission.MESSAGE_SEND_IN_THREADS, false,
-					Permission.VIEW_AUDIT_LOGS, false,
 					Permission.VIEW_CHANNEL, false));
 			
 			
 			GuildChannel currentChannel = guild.getGuildChannelById(event.getChannelIdLong());
 			
-			if(currentChannel!=null) {
-				currentChannel
-				.getPermissionContainer()
-				.getRolePermissionOverrides()
-				.forEach(permission -> {
-					if(permission.getRole().equals(botIntegrationRole)) {
-						EnumSet<Permission> allowedPermList = permission.getAllowed();
-						EnumSet<Permission> deniedPermList = permission.getDenied();
-						
-						requiredPermissions.entrySet().forEach(p -> {
-							if(allowedPermList.contains(p.getKey())) {
-								p.setValue(true);
-							}
-							
-							if(deniedPermList.contains(p.getKey())) {
-								p.setValue(false);
-							}
-						});
+			if(currentChannel==null || botMember == null) {
+				eb.addField("Channel Specific Permissions","ERROR: Could not determine bot permissions for the given channel. Channel possibly not supported", false);
+			} else {
+				botMember.getPermissions(currentChannel).forEach(permission ->{
+					if(requiredPermissions.containsKey(permission)) {
+						requiredPermissions.replace(permission, true);
 					}
 				});
 				
@@ -70,9 +60,11 @@ public class RequiredPermissionCheckListener extends ListenerAdapter {
 					finalPermissions.append(permission.getKey().getName()+System.lineSeparator());
 				});
 				
-				eb.addField("The following set of required permissions are granted to the bot in the channel: "+currentChannel.getAsMention(), finalPermissions.toString(), false);
+				
+				eb.addField("Channel Specific Permissions: "+currentChannel.getAsMention(), finalPermissions.toString(), false);
 			}
-							
+			
+										
 			MessageEmbed mb = eb.build();
 			event.replyEmbeds(mb).queue();
 		}

--- a/src/main/java/org/papertrail/listeners/customlisteners/RequiredPermissionCheckListener.java
+++ b/src/main/java/org/papertrail/listeners/customlisteners/RequiredPermissionCheckListener.java
@@ -54,10 +54,34 @@ public class RequiredPermissionCheckListener extends ListenerAdapter {
 				botRolePermissions.append(permission.getKey().getName()+System.lineSeparator());
 			});
 			
-			eb.addField("The following set of required permissions are granted to the bot's role: ", botRolePermissions.toString(), false);
+			eb.addField("The following set of required permissions are granted to the bot's role: "+botIntegrationRole.getAsMention(), botRolePermissions.toString(), false);
 			
 			// reset the permission status
 			requiredPermissions.entrySet().forEach(permission -> requiredPermissions.replace(permission.getKey(), false));
+						
+			guild.getGuildChannelById(event.getChannelIdLong()).getPermissionContainer().getRolePermissionOverrides().forEach(override -> {
+				if(override.getRole().equals(botIntegrationRole)) {
+					
+					override.getAllowed().forEach(allowedPermission -> {
+						if(requiredPermissions.get(allowedPermission)!=null) {
+							requiredPermissions.replace(allowedPermission, true);
+						}
+					});
+					
+					override.getDenied().forEach(deniedPermission -> {
+						if(requiredPermissions.get(deniedPermission)!=null) {
+							requiredPermissions.replace(deniedPermission, false);
+						}
+					});
+				}
+			});	
+			
+			StringBuilder channelPermissionsForBotRole = new StringBuilder();
+			requiredPermissions.entrySet().forEach(permission -> {
+				channelPermissionsForBotRole.append(Boolean.TRUE.equals(permission.getValue()) ? "✅" : "❌");
+				channelPermissionsForBotRole.append(permission.getKey().getName()+System.lineSeparator());
+			});
+			eb.addField("The following set of permission overrides are granted to the bot's role for this channel: ", channelPermissionsForBotRole.toString(), false);
 			
 			MessageEmbed mb = eb.build();
 			event.replyEmbeds(mb).queue();

--- a/src/main/java/org/papertrail/listeners/customlisteners/RequiredPermissionCheckListener.java
+++ b/src/main/java/org/papertrail/listeners/customlisteners/RequiredPermissionCheckListener.java
@@ -1,0 +1,66 @@
+package org.papertrail.listeners.customlisteners;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.SelfUser;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class RequiredPermissionCheckListener extends ListenerAdapter {
+	
+	@Override
+	public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+		
+		if (event.getName().equals("permcheck")) {
+			
+			Guild guild = event.getGuild();
+					
+			SelfUser botAsUser = event.getJDA().getSelfUser();
+			Role botIntegrationRole = guild.getRoleByBot(botAsUser);
+			
+			EmbedBuilder eb = new EmbedBuilder();
+			eb.setTitle("PaperTrail Permissions Checker");
+			eb.setDescription("Helps determine whether the required permissions are granted for PaperTrail to function properly");
+			
+			// create a map of required permissions and set all their statuses to false
+			Map<Permission, Boolean> requiredPermissions = new EnumMap<>(Permission.class);
+			requiredPermissions.putAll(Map.of(
+					Permission.MESSAGE_EMBED_LINKS, false,
+					Permission.MESSAGE_HISTORY, false,
+					Permission.MESSAGE_SEND, false,
+					Permission.MESSAGE_SEND_IN_THREADS, false,
+					Permission.VIEW_AUDIT_LOGS, false,
+					Permission.VIEW_CHANNEL, false));
+			
+			
+			// iterate over the permissions granted to the bot's role and see if it intersects with the required permissions
+			// if intersection exists for a particular permission, change it's status to true
+			botIntegrationRole.getPermissions().forEach(permission -> {
+				if(requiredPermissions.get(permission)!=null) {
+					requiredPermissions.replace(permission, true);
+				}
+			});
+			
+			// iterate over the required permissions map and see what required permissions have been granted for the bot's integration role
+			StringBuilder botRolePermissions = new StringBuilder();
+			requiredPermissions.entrySet().forEach(permission -> {
+				botRolePermissions.append(Boolean.TRUE.equals(permission.getValue()) ? "✅" : "❌");
+				botRolePermissions.append(permission.getKey().getName()+System.lineSeparator());
+			});
+			
+			eb.addField("The following set of required permissions are granted to the bot's role: ", botRolePermissions.toString(), false);
+			
+			// reset the permission status
+			requiredPermissions.entrySet().forEach(permission -> requiredPermissions.replace(permission.getKey(), false));
+			
+			MessageEmbed mb = eb.build();
+			event.replyEmbeds(mb).queue();
+		}
+	}
+}

--- a/src/main/java/org/papertrail/listeners/customlisteners/RequiredPermissionCheckListener.java
+++ b/src/main/java/org/papertrail/listeners/customlisteners/RequiredPermissionCheckListener.java
@@ -1,5 +1,6 @@
 package org.papertrail.listeners.customlisteners;
 
+import java.awt.Color;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -30,6 +31,7 @@ public class RequiredPermissionCheckListener extends ListenerAdapter {
 			EmbedBuilder eb = new EmbedBuilder();
 			eb.setTitle("PaperTrail Permissions Checker");
 			eb.setDescription("Helps determine whether the required permissions are granted for PaperTrail to function properly");
+			eb.setColor(Color.MAGENTA);
 			
 			eb.addField("Bot Integration Role Specific Permission", (botIntegrationRole.hasPermission(Permission.VIEW_AUDIT_LOGS) ? "✅" : "❌")+Permission.VIEW_AUDIT_LOGS.getName(), false);
 			

--- a/src/main/java/org/papertrail/listeners/guildlisteners/ServerBoostListener.java
+++ b/src/main/java/org/papertrail/listeners/guildlisteners/ServerBoostListener.java
@@ -56,6 +56,7 @@ public class ServerBoostListener extends ListenerAdapter {
 	        eb.addField("🪫 Booster Lost", "╰┈➤"+mentionableMember+" has removed their boost from your server", false);
 	        eb.addField("📉 Remaining Boosts In The Server", "╰┈➤"+guild.getBoostCount(), false);
 	        eb.addField("🎖️ Current Boost Tier", "╰┈➤"+guild.getBoostTier().toString(), false);
+	        eb.addField("Notice", "Boosts remain active for a period even after a member stops boosting, so the server's boost count doesn't update immediately.", false);
 	    }
 	    
 	    eb.setFooter("Server Boost Detection");

--- a/src/main/java/org/papertrail/main/FireRun.java
+++ b/src/main/java/org/papertrail/main/FireRun.java
@@ -12,6 +12,7 @@ import org.papertrail.listeners.customlisteners.AnnouncementListener;
 import org.papertrail.listeners.customlisteners.BotInfoListener;
 import org.papertrail.listeners.customlisteners.ServerStatListener;
 import org.papertrail.listeners.customlisteners.BotSetupListener;
+import org.papertrail.listeners.customlisteners.RequiredPermissionCheckListener;
 import org.papertrail.listeners.guildlisteners.ServerBoostListener;
 import org.papertrail.listeners.loglisteners.AuditLogListener;
 import org.papertrail.listeners.loglisteners.AuditLogCommandListener;
@@ -59,6 +60,7 @@ public class FireRun {
 		ci.getManager().addEventListener(new BotInfoListener());
 		ci.getManager().addEventListener(new BotSetupListener());
 		ci.getManager().addEventListener(new AnnouncementListener(dc));
+		ci.getManager().addEventListener(new RequiredPermissionCheckListener());
 		
 		/*
 		 * This is required only to set up a cron-job to periodically ping this end-point so that

--- a/src/main/java/org/papertrail/main/SlashCommandRegistrar.java
+++ b/src/main/java/org/papertrail/main/SlashCommandRegistrar.java
@@ -47,6 +47,8 @@ public class SlashCommandRegistrar extends ListenerAdapter {
 				.addOption(OptionType.STRING, "detail", "Detailed Information", true)
 				.addOption(OptionType.STRING, "extra", "Extra Notes", false);
 		
+		CommandData permCheck = Commands.slash("permcheck", "Checks if the bot has the necessary permissions to operate");
+		
 		jda.updateCommands()
 				.addCommands(auditLogChannelRegistration,
 						auditLogChannelFetch,
@@ -57,7 +59,8 @@ public class SlashCommandRegistrar extends ListenerAdapter {
 						serverStats,
 						botInfo,
 						setup,
-						announcement)			
+						announcement,
+						permCheck)			
 				.queue();
 	}
 }

--- a/src/main/java/org/papertrail/version/ProjectInfo.java
+++ b/src/main/java/org/papertrail/version/ProjectInfo.java
@@ -7,7 +7,7 @@ public class ProjectInfo {
 	}
 	
 	public static final String APPNAME = "PaperTrail";
-	public static final String VERSION = "v1.1.0";
+	public static final String VERSION = "v1.2.0";
 	public static final String PROJECT_LINK = "https://github.com/Egg-03/PaperTrailBot";
 	public static final String PROJECT_ISSUE_LINK="https://github.com/Egg-03/PaperTrailBot/issues";
 	


### PR DESCRIPTION
- Introduced a new /permcheck slash command to verify if the bot has the required permissions to function properly.
- A message now appears when a boost is lost in a guild, explaining that the boost count may not update immediately, as boosts remain active for a short period even after a member removes their boost.