### PR TITLE
refactor(api): replace unirest with spring restclient and vavr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,17 @@
 		 <artifactId>guava</artifactId>
 		 <version>33.4.8-jre</version>
 	 </dependency>
+     <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-restclient -->
      <dependency>
-         <groupId>com.konghq</groupId>
-         <artifactId>unirest-java-core</artifactId>
-         <version>4.5.0</version>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-restclient</artifactId>
+         <version>4.0.0-M2</version>
+     </dependency>
+     <!-- https://mvnrepository.com/artifact/io.vavr/vavr -->
+     <dependency>
+         <groupId>io.vavr</groupId>
+         <artifactId>vavr</artifactId>
+         <version>0.10.7</version>
      </dependency>
      <dependency>
          <groupId>com.google.code.gson</groupId>

--- a/src/main/java/org/papertrail/listeners/loglisteners/AuditLogListener.java
+++ b/src/main/java/org/papertrail/listeners/loglisteners/AuditLogListener.java
@@ -6,12 +6,12 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 
+import io.vavr.control.Either;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.papertrail.sdk.client.AuditLogClient;
-import org.papertrail.sdk.http.HttpServiceResponse;
-import org.papertrail.sdk.model.AuditLogResponse;
-import org.papertrail.sdk.model.ErrorResponse;
+import org.papertrail.sdk.model.AuditLogObject;
+import org.papertrail.sdk.model.ErrorObject;
 import org.papertrail.utilities.ColorFormatter;
 import org.papertrail.utilities.DurationFormatter;
 import org.papertrail.utilities.GuildSystemChannelFlagResolver;
@@ -50,12 +50,11 @@ public class AuditLogListener extends ListenerAdapter{
 		vThreadPool.execute(()->{
 
             // Call the API and see if the event came from a registered Guild
-            HttpServiceResponse<AuditLogResponse, ErrorResponse> guildCheck = AuditLogClient.getRegisteredGuild(event.getGuild().getId());
-
-            if(guildCheck.requestSuccess()){
+            Either<ErrorObject, AuditLogObject> response  = AuditLogClient.getRegisteredGuild(event.getGuild().getId());
+            response.peek(success -> {
                 AuditLogEntry ale = event.getEntry();
-                auditLogParser(event, ale, guildCheck.success().channelId());
-            }
+                auditLogParser(event, ale, success.channelId());
+            });
 
 		});
 	}

--- a/src/main/java/org/papertrail/listeners/voicelisteners/GuildVoiceListener.java
+++ b/src/main/java/org/papertrail/listeners/voicelisteners/GuildVoiceListener.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 
+import io.vavr.control.Either;
 import org.jetbrains.annotations.NotNull;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Member;
@@ -13,9 +14,8 @@ import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.papertrail.sdk.client.AuditLogClient;
-import org.papertrail.sdk.http.HttpServiceResponse;
-import org.papertrail.sdk.model.AuditLogResponse;
-import org.papertrail.sdk.model.ErrorResponse;
+import org.papertrail.sdk.model.AuditLogObject;
+import org.papertrail.sdk.model.ErrorObject;
 
 public class GuildVoiceListener extends ListenerAdapter {
 
@@ -32,47 +32,48 @@ public class GuildVoiceListener extends ListenerAdapter {
 
 			// guild voice events are mapped to audit log table
             // Call the API and see if the event came from a registered Guild
-            HttpServiceResponse<AuditLogResponse, ErrorResponse> guildCheck = AuditLogClient.getRegisteredGuild(event.getGuild().getId());
+            Either<ErrorObject, AuditLogObject> response = AuditLogClient.getRegisteredGuild(event.getGuild().getId());
 
-            if(!guildCheck.requestSuccess()){
-                return ;
-            }
-			String registeredChannelId = guildCheck.success().channelId();
+            response.peek(success -> {
 
-			EmbedBuilder eb = new EmbedBuilder();
-			eb.setTitle("🔊 Voice Activity Log");
+                String registeredChannelId = success.channelId();
 
-			Member member = event.getMember();
-			AudioChannel left = event.getOldValue(); // can be null if user joined for first time
-			AudioChannel joined = event.getNewValue(); // can be null if user left
+                EmbedBuilder eb = new EmbedBuilder();
+                eb.setTitle("🔊 Voice Activity Log");
 
-			if(left==null && joined!=null) {
-				// User has joined a vc
-				eb.setDescription("A Member has joined a voice channel");
-				eb.setColor(Color.GREEN);
-				eb.addField("✅ Member Joined", "╰┈➤"+member.getAsMention()+" joined the voice channel "+joined.getAsMention(), false);
-			}
+                Member member = event.getMember();
+                AudioChannel left = event.getOldValue(); // can be null if user joined for first time
+                AudioChannel joined = event.getNewValue(); // can be null if user left
 
-			if (left != null && joined != null) {
-				// Moved from one channel to another
-				eb.setDescription("A Member has switched voice channels");
-				eb.setColor(Color.YELLOW);
-				eb.addField("🔄 Member Switched Channels", "╰┈➤"+member.getAsMention()+" joined the switched from channel "+left.getAsMention()+ " to "+joined.getAsMention(), false);
-			}
+                if(left==null && joined!=null) {
+                    // User has joined a vc
+                    eb.setDescription("A Member has joined a voice channel");
+                    eb.setColor(Color.GREEN);
+                    eb.addField("✅ Member Joined", "╰┈➤"+member.getAsMention()+" joined the voice channel "+joined.getAsMention(), false);
+                }
 
-			if (left!=null && joined==null) {
-				// User disconnected voluntarily (or was disconnected by a moderator)
-				eb.setDescription("A Member has left a voice channel");
-				eb.setColor(Color.RED);
-				eb.addField("❌ Member Left A Voice Channel", "╰┈➤"+member.getAsMention()+" left the voice channel "+left.getAsMention(), false);
-			}
+                if (left != null && joined != null) {
+                    // Moved from one channel to another
+                    eb.setDescription("A Member has switched voice channels");
+                    eb.setColor(Color.YELLOW);
+                    eb.addField("🔄 Member Switched Channels", "╰┈➤"+member.getAsMention()+" joined the switched from channel "+left.getAsMention()+ " to "+joined.getAsMention(), false);
+                }
 
-			eb.setFooter("Voice Activity Detection");
-			eb.setTimestamp(Instant.now());
+                if (left!=null && joined==null) {
+                    // User disconnected voluntarily (or was disconnected by a moderator)
+                    eb.setDescription("A Member has left a voice channel");
+                    eb.setColor(Color.RED);
+                    eb.addField("❌ Member Left A Voice Channel", "╰┈➤"+member.getAsMention()+" left the voice channel "+left.getAsMention(), false);
+                }
 
-			MessageEmbed mb = eb.build();
+                eb.setFooter("Voice Activity Detection");
+                eb.setTimestamp(Instant.now());
 
-			Objects.requireNonNull(event.getGuild().getTextChannelById(registeredChannelId)).sendMessageEmbeds(mb).queue();
+                MessageEmbed mb = eb.build();
+
+                Objects.requireNonNull(event.getGuild().getTextChannelById(registeredChannelId)).sendMessageEmbeds(mb).queue();
+            });
+
 		});
 	}
 }

--- a/src/main/java/org/papertrail/main/FireRun.java
+++ b/src/main/java/org/papertrail/main/FireRun.java
@@ -65,11 +65,8 @@ public class FireRun {
 		manager.addEventListener(new BotInfoCommandListener());
 		manager.addEventListener(new BotSetupCommandListener());
 		manager.addEventListener(new RequiredPermissionCheckCommandListener());
-		
-		/*
-		 * This is required only to set up a cron-job to periodically ping this end-point so that
-		 * hosting services that spin down after inactivity don't do that anymore
-		 */
+
+        // Custom health check endpoint
 		HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
         server.createContext("/ping", new PingHandler());
         server.setExecutor(null); // creates a default executor

--- a/src/main/java/org/papertrail/sdk/client/AuditLogClient.java
+++ b/src/main/java/org/papertrail/sdk/client/AuditLogClient.java
@@ -1,67 +1,72 @@
 package org.papertrail.sdk.client;
 
-import kong.unirest.core.HttpMethod;
+import io.vavr.control.Either;
+import org.jetbrains.annotations.NotNull;
 import org.papertrail.sdk.http.HttpServiceEngine;
-import org.papertrail.sdk.http.HttpServiceResponse;
-import org.papertrail.sdk.model.ErrorResponse;
-import org.papertrail.sdk.model.AuditLogResponse;
+import org.papertrail.sdk.model.AuditLogObject;
+import org.papertrail.sdk.model.ErrorObject;
 import org.papertrail.utilities.EnvConfig;
-import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+import java.util.List;
 
 public class AuditLogClient {
 
-    private AuditLogClient(){
-        throw  new IllegalStateException("Utility Class");
+    private static final String BASE_URL = EnvConfig.get("API_URL");
+    private static final HttpHeaders httpHeaders = new HttpHeaders();
+    private static final HttpServiceEngine engine = HttpServiceEngine.getInstance();
+
+    static {
+        httpHeaders.put("Content-Type", List.of("application/json"));
     }
 
-    private static final String BASE_URL = EnvConfig.get("API_URL");
-    private static final Map<String, String > CONTENT_HEADER = Map.of("Content-Type", "application/json");
+    private AuditLogClient() {
+        throw new IllegalStateException("Client class");
+    }
 
-    public static HttpServiceResponse<AuditLogResponse, ErrorResponse> registerGuild(String guildId, String channelId){
+    @NotNull
+    public static Either<ErrorObject, AuditLogObject> registerGuild(String guildId, String channelId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequestWithBody(
                 HttpMethod.POST,
                 BASE_URL +"api/v1/log/audit",
-                CONTENT_HEADER,
-                new AuditLogResponse(guildId, channelId),
-                AuditLogResponse.class,
-                ErrorResponse.class
+                httpHeaders,
+                new AuditLogObject(guildId, channelId),
+                AuditLogObject.class
         );
     }
 
-    public static HttpServiceResponse<AuditLogResponse, ErrorResponse> getRegisteredGuild(String guildId){
+    @NotNull
+    public static Either<ErrorObject, AuditLogObject> getRegisteredGuild(String guildId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequest(
                 HttpMethod.GET,
                 BASE_URL +"api/v1/log/audit/"+guildId,
-                CONTENT_HEADER,
-                null,
-                AuditLogResponse.class,
-                ErrorResponse.class
+                httpHeaders,
+                AuditLogObject.class
         );
     }
 
-    public static HttpServiceResponse<AuditLogResponse, ErrorResponse> updateRegisteredGuild(String guildId, String channelId){
+    @NotNull
+    public static Either<ErrorObject, AuditLogObject> updateRegisteredGuild(String guildId, String channelId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequestWithBody(
                 HttpMethod.PUT,
                 BASE_URL +"api/v1/log/audit",
-                CONTENT_HEADER,
-                new AuditLogResponse(guildId, channelId),
-                AuditLogResponse.class,
-                ErrorResponse.class
+                httpHeaders,
+                new AuditLogObject(guildId, channelId),
+                AuditLogObject.class
         );
     }
 
-    public static HttpServiceResponse<Void, ErrorResponse> deleteRegisteredGuild(String guildId){
+    public static Either<ErrorObject, Void> deleteRegisteredGuild(String guildId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequest(
                 HttpMethod.DELETE,
                 BASE_URL +"api/v1/log/audit/"+guildId,
-                CONTENT_HEADER,
-                null,
-                Void.class,
-                ErrorResponse.class
+                httpHeaders,
+                Void.class
         );
     }
 }

--- a/src/main/java/org/papertrail/sdk/client/MessageContentLogClient.java
+++ b/src/main/java/org/papertrail/sdk/client/MessageContentLogClient.java
@@ -1,69 +1,74 @@
 package org.papertrail.sdk.client;
 
-import kong.unirest.core.HttpMethod;
+import io.vavr.control.Either;
+import org.jetbrains.annotations.NotNull;
 import org.papertrail.sdk.http.HttpServiceEngine;
-import org.papertrail.sdk.http.HttpServiceResponse;
-import org.papertrail.sdk.model.ErrorResponse;
-import org.papertrail.sdk.model.MessageContentResponse;
+import org.papertrail.sdk.model.ErrorObject;
+import org.papertrail.sdk.model.MessageContentObject;
 import org.papertrail.utilities.EnvConfig;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 
-import java.util.Map;
+import java.util.List;
 
 public class MessageContentLogClient {
 
-    private MessageContentLogClient(){
-        throw  new IllegalStateException("Utility Class");
+    private static final String BASE_URL = EnvConfig.get("API_URL")+"api/v1/content/message";
+    private static final HttpHeaders httpHeaders = new HttpHeaders();
+    private static final HttpServiceEngine engine = HttpServiceEngine.getInstance();
+
+    static {
+        httpHeaders.put("Content-Type", List.of("application/json"));
     }
 
-    private static final String BASE_URL = EnvConfig.get("API_URL")+"api/v1/content/message";
-    private static final Map<String, String > CONTENT_HEADER = Map.of("Content-Type", "application/json");
+    private MessageContentLogClient() {
+        throw new IllegalStateException("Client class");
+    }
 
-    public static HttpServiceResponse<MessageContentResponse, ErrorResponse> logMessage(String messageId, String messageContent, String authorId){
+    @NotNull
+    public static Either<ErrorObject, MessageContentObject> logMessage(String messageId, String messageContent, String authorId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequestWithBody(
                 HttpMethod.POST,
                 BASE_URL,
-                CONTENT_HEADER,
-                new MessageContentResponse(messageId, messageContent, authorId),
-                MessageContentResponse.class,
-                ErrorResponse.class
+                httpHeaders,
+                new MessageContentObject(messageId, messageContent, authorId),
+                MessageContentObject.class
         );
 
     }
 
-    public static HttpServiceResponse<MessageContentResponse, ErrorResponse> retrieveMessage(String messageId){
+    @NotNull
+    public static Either<ErrorObject, MessageContentObject> retrieveMessage(String messageId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequest(
                 HttpMethod.GET,
                 BASE_URL+"/"+messageId,
-                CONTENT_HEADER,
-                null,
-                MessageContentResponse.class,
-                ErrorResponse.class
+                httpHeaders,
+                MessageContentObject.class
         );
     }
 
-    public static HttpServiceResponse<MessageContentResponse, ErrorResponse> updateMessage(String messageId, String messageContent, String authorId){
+    @NotNull
+    public static Either<ErrorObject, MessageContentObject> updateMessage(String messageId, String messageContent, String authorId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequestWithBody(
                 HttpMethod.PUT,
                 BASE_URL,
-                CONTENT_HEADER,
-                new MessageContentResponse(messageId, messageContent, authorId),
-                MessageContentResponse.class,
-                ErrorResponse.class
+                httpHeaders,
+                new MessageContentObject(messageId, messageContent, authorId),
+                MessageContentObject.class
         );
     }
 
-    public static HttpServiceResponse<Void, ErrorResponse> deleteMessage(String messageId) {
+    @NotNull
+    public static Either<ErrorObject, Void> deleteMessage(String messageId) {
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequest(
                 HttpMethod.DELETE,
                 BASE_URL+"/"+messageId,
-                CONTENT_HEADER,
-                null,
-                Void.class,
-                ErrorResponse.class
+                httpHeaders,
+                Void.class
         );
 
     }

--- a/src/main/java/org/papertrail/sdk/client/MessageLogClient.java
+++ b/src/main/java/org/papertrail/sdk/client/MessageLogClient.java
@@ -1,69 +1,72 @@
 package org.papertrail.sdk.client;
 
-import kong.unirest.core.HttpMethod;
+import io.vavr.control.Either;
+import org.jetbrains.annotations.NotNull;
 import org.papertrail.sdk.http.HttpServiceEngine;
-import org.papertrail.sdk.http.HttpServiceResponse;
-import org.papertrail.sdk.model.ErrorResponse;
-import org.papertrail.sdk.model.MessageLogResponse;
+import org.papertrail.sdk.model.ErrorObject;
+import org.papertrail.sdk.model.MessageLogObject;
 import org.papertrail.utilities.EnvConfig;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 
-import java.util.Map;
+import java.util.List;
+
 
 public class MessageLogClient {
 
-    private MessageLogClient(){
-        throw  new IllegalStateException("Utility Class");
+    private static final String BASE_URL = EnvConfig.get("API_URL");
+    private static final HttpHeaders httpHeaders = new HttpHeaders();
+    private static final HttpServiceEngine engine = HttpServiceEngine.getInstance();
+
+    static {
+        httpHeaders.put("Content-Type", List.of("application/json"));
     }
 
-    private static final String BASE_URL = EnvConfig.get("API_URL");
-    private static final Map<String, String > CONTENT_HEADER = Map.of("Content-Type", "application/json");
+    private MessageLogClient(){
+        throw new IllegalStateException("Client class");
+    }
 
-    public static HttpServiceResponse<MessageLogResponse, ErrorResponse> registerGuild(String guildId, String channelId){
+    @NotNull
+    public static Either<ErrorObject, MessageLogObject> registerGuild(String guildId, String channelId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequestWithBody(
                 HttpMethod.POST,
                 BASE_URL +"api/v1/log/message",
-                CONTENT_HEADER,
-                new MessageLogResponse(guildId, channelId),
-                MessageLogResponse.class,
-                ErrorResponse.class
+                httpHeaders,
+                new MessageLogObject(guildId, channelId),
+                MessageLogObject.class
         );
     }
 
-    public static HttpServiceResponse<MessageLogResponse, ErrorResponse> getRegisteredGuild(String guildId){
+    public static Either<ErrorObject, MessageLogObject> getRegisteredGuild(String guildId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequest(
                 HttpMethod.GET,
                 BASE_URL +"api/v1/log/message/"+guildId,
-                CONTENT_HEADER,
-                null,
-                MessageLogResponse.class,
-                ErrorResponse.class
+                httpHeaders,
+                MessageLogObject.class
         );
 
     }
 
-    public static HttpServiceResponse<MessageLogResponse, ErrorResponse> updateRegisteredGuild(String guildId, String channelId){
+    public static Either<ErrorObject, MessageLogObject> updateRegisteredGuild(String guildId, String channelId){
 
-        return HttpServiceEngine.makeRequest(
+        return HttpServiceEngine.getInstance().makeRequestWithBody(
                 HttpMethod.PUT,
-                BASE_URL +"api/v1/log/message",
-                CONTENT_HEADER,
-                new MessageLogResponse(guildId, channelId),
-                MessageLogResponse.class,
-                ErrorResponse.class
+                BASE_URL + "api/v1/log/message",
+                httpHeaders,
+                new MessageLogObject(guildId, channelId),
+                MessageLogObject.class
         );
     }
 
-    public static HttpServiceResponse<Void, ErrorResponse> deleteRegisteredGuild(String guildId){
+    public static Either<ErrorObject, Void> deleteRegisteredGuild(String guildId){
 
-        return HttpServiceEngine.makeRequest(
+        return engine.makeRequest(
                 HttpMethod.DELETE,
                 BASE_URL +"api/v1/log/message/"+guildId,
-                CONTENT_HEADER,
-                null,
-                Void.class,
-                ErrorResponse.class
+                httpHeaders,
+                Void.class
         );
     }
 }

--- a/src/main/java/org/papertrail/sdk/http/HttpServiceResponse.java
+++ b/src/main/java/org/papertrail/sdk/http/HttpServiceResponse.java
@@ -1,7 +1,0 @@
-package org.papertrail.sdk.http;
-
-import org.jspecify.annotations.Nullable;
-
-public record HttpServiceResponse<S, E>(@Nullable S success, @Nullable E error, boolean requestSuccess) {
-
-}

--- a/src/main/java/org/papertrail/sdk/model/AuditLogObject.java
+++ b/src/main/java/org/papertrail/sdk/model/AuditLogObject.java
@@ -1,0 +1,5 @@
+package org.papertrail.sdk.model;
+
+public record AuditLogObject(String guildId, String channelId) {
+
+}

--- a/src/main/java/org/papertrail/sdk/model/AuditLogResponse.java
+++ b/src/main/java/org/papertrail/sdk/model/AuditLogResponse.java
@@ -1,5 +1,0 @@
-package org.papertrail.sdk.model;
-
-public record AuditLogResponse(String guildId, String channelId) {
-
-}

--- a/src/main/java/org/papertrail/sdk/model/ErrorObject.java
+++ b/src/main/java/org/papertrail/sdk/model/ErrorObject.java
@@ -1,6 +1,6 @@
 package org.papertrail.sdk.model;
 
-public record ErrorResponse(
+public record ErrorObject(
         int status,
         String error,
         String message,

--- a/src/main/java/org/papertrail/sdk/model/MessageContentObject.java
+++ b/src/main/java/org/papertrail/sdk/model/MessageContentObject.java
@@ -1,0 +1,4 @@
+package org.papertrail.sdk.model;
+
+public record MessageContentObject(String messageId, String messageContent, String authorId) {
+}

--- a/src/main/java/org/papertrail/sdk/model/MessageContentResponse.java
+++ b/src/main/java/org/papertrail/sdk/model/MessageContentResponse.java
@@ -1,4 +1,0 @@
-package org.papertrail.sdk.model;
-
-public record MessageContentResponse(String messageId, String messageContent, String authorId) {
-}

--- a/src/main/java/org/papertrail/sdk/model/MessageLogObject.java
+++ b/src/main/java/org/papertrail/sdk/model/MessageLogObject.java
@@ -1,0 +1,5 @@
+package org.papertrail.sdk.model;
+
+public record MessageLogObject(String guildId, String channelId) {
+
+}

--- a/src/main/java/org/papertrail/sdk/model/MessageLogResponse.java
+++ b/src/main/java/org/papertrail/sdk/model/MessageLogResponse.java
@@ -1,5 +1,0 @@
-package org.papertrail.sdk.model;
-
-public record MessageLogResponse(String guildId, String channelId) {
-
-}

--- a/src/main/java/org/papertrail/version/ProjectInfo.java
+++ b/src/main/java/org/papertrail/version/ProjectInfo.java
@@ -7,7 +7,7 @@ public class ProjectInfo {
 	}
 	
 	public static final String APPNAME = "PaperTrail";
-	public static final String VERSION = "v2.0.0-beta";
+	public static final String VERSION = "v2.0.0";
 	public static final String PROJECT_LINK = "https://github.com/Egg-03/PaperTrailBot";
 	public static final String PROJECT_ISSUE_LINK="https://github.com/Egg-03/PaperTrailBot/issues";
 	


### PR DESCRIPTION
Replaces the Unirest HTTP client library with Spring's RestClient and introduces Vavr's Either for functional error handling. This change refactors the HttpServiceEngine, all API clients, and updates DTOs and API response handling in listeners.

Benefits:
- Improves error handling with explicit success/failure states using Either.
- Adopts a modern and actively maintained HTTP client.
- Enhances consistency and maintainability of API interactions.