### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.egg.papertrail</groupId>
   <artifactId>paper-trail-bot</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <name>PaperTrail</name>
   <description>A simple bot for logging all user actions</description>
   <properties>
@@ -16,7 +16,7 @@
 	<dependency>
     	<groupId>net.dv8tion</groupId>
     	<artifactId>JDA</artifactId>
-    	<version>5.6.1</version>
+    	<version>6.0.0</version>
 	</dependency>
 	<dependency>
     	<groupId>org.tinylog</groupId>

--- a/src/main/java/org/papertrail/listeners/loglisteners/AuditLogListener.java
+++ b/src/main/java/org/papertrail/listeners/loglisteners/AuditLogListener.java
@@ -112,7 +112,7 @@ public class AuditLogListener extends ListenerAdapter{
 		case MEMBER_VOICE_KICK -> formatMemberVoiceKick(event, ale, channelIdToSendTo);
 		case MEMBER_VOICE_MOVE -> formatMemberVoiceMove(event, ale, channelIdToSendTo);
 		
-		// this seemingly don't trigger properly, or are unreliable
+		// these seemingly don't trigger properly, or are unreliable
 		case MESSAGE_BULK_DELETE -> formatGeneric(event, ale, channelIdToSendTo);
 		case MESSAGE_CREATE -> formatGeneric(event, ale, channelIdToSendTo);
 		case MESSAGE_DELETE -> formatGeneric(event, ale, channelIdToSendTo);
@@ -1980,7 +1980,7 @@ public class AuditLogListener extends ListenerAdapter{
 		
 		eb.addField("Action Type", String.valueOf(ale.getType()), true);
 		eb.addField("Target Type", String.valueOf(ale.getTargetType()), true);
-		
+
 		eb.setFooter("Audit Log Entry ID: "+ale.getId());
 		eb.setTimestamp(ale.getTimeCreated());
 

--- a/src/main/java/org/papertrail/utilities/PermissionResolver.java
+++ b/src/main/java/org/papertrail/utilities/PermissionResolver.java
@@ -2,6 +2,9 @@ package org.papertrail.utilities;
 
 import java.util.Map;
 
+/**
+ @see <a href="https://discord.com/developers/docs/topics/permissions">Discord Permissions</a>
+ */
 public class PermissionResolver {
 	
 	private static final Map<Long, String> PERMISSION_MAP = Map.ofEntries(
@@ -30,7 +33,7 @@ public class PermissionResolver {
 	        Map.entry(1L << 22, "MUTE_MEMBERS"),
 	        Map.entry(1L << 23, "DEAFEN_MEMBERS"),
 	        Map.entry(1L << 24, "MOVE_MEMBERS"),
-	        Map.entry(1L << 25, "USE_VOICE_ACTIVITY_DETECTION"),
+	        Map.entry(1L << 25, "USE_VAD"),
 	        Map.entry(1L << 26, "CHANGE_NICKNAME"),
 	        Map.entry(1L << 27, "MANAGE_NICKNAMES"),
 	        Map.entry(1L << 28, "MANAGE_ROLES"),
@@ -54,7 +57,8 @@ public class PermissionResolver {
 	        Map.entry(1L << 46, "SEND_VOICE_MESSAGES"),
 	        
 	        Map.entry(1L << 49, "SEND_POLLS"),
-	        Map.entry(1L << 50, "USE_EXTERNAL_APPS")
+	        Map.entry(1L << 50, "USE_EXTERNAL_APPS"),
+            Map.entry(1L << 51, "PIN_MESSAGES")
 			);
 	
 	private PermissionResolver() {

--- a/src/main/java/org/papertrail/version/AuthorInfo.java
+++ b/src/main/java/org/papertrail/version/AuthorInfo.java
@@ -7,6 +7,6 @@ public class AuthorInfo {
 	}
 	
 	public static final String AUTHOR_NAME="Egg-03";
-	public static final String AUTHOR_LINK = "https://github.com/Egg-03";
-	public static final String AUTHOR_AVATAR_URL="https://avatars.githubusercontent.com/Egg-03";
+	public static final String AUTHOR_LINK = "https://github.com/eggy03";
+	public static final String AUTHOR_AVATAR_URL="https://avatars.githubusercontent.com/eggy03";
 }

--- a/src/main/java/org/papertrail/version/ProjectInfo.java
+++ b/src/main/java/org/papertrail/version/ProjectInfo.java
@@ -7,9 +7,9 @@ public class ProjectInfo {
 	}
 	
 	public static final String APPNAME = "PaperTrail";
-	public static final String VERSION = "v2.0.0";
-	public static final String PROJECT_LINK = "https://github.com/Egg-03/PaperTrailBot";
-	public static final String PROJECT_ISSUE_LINK="https://github.com/Egg-03/PaperTrailBot/issues";
+	public static final String VERSION = "v2.0.1";
+	public static final String PROJECT_LINK = "https://github.com/eggy03/PaperTrailBot";
+	public static final String PROJECT_ISSUE_LINK="https://github.com/eggy03/PaperTrailBot/issues";
 	
 	public static final String PRIVACY = "https://github.com/Egg-03/PaperTrailBot/blob/main/PRIVACY.md";
 	public static final String TERMS = "https://github.com/Egg-03/PaperTrailBot/blob/main/TERMS.md";


### PR DESCRIPTION
1. Migrate from JDA v5.6.1 to v6 36b7e671d18a3e9e1f4d4bebf2bb6414f00ef6ef
2. Add a new permission `PIN_MESSAGES` since `MANAGE_MESSAGES` no longer allow pinning of messages [See discord permissions documenation](https://discord.com/developers/docs/topics/permissions) 36b7e671d18a3e9e1f4d4bebf2bb6414f00ef6ef
3. `USE_VOICE_ACTIVITY_DETECTION` has been renamed to `USE_VAD` [See discord permissions documentation](https://discord.com/developers/docs/topics/permissions) 36b7e671d18a3e9e1f4d4bebf2bb6414f00ef6ef
4. Update author links fa6a99340049f48eaccd126f5d2e722ce39367d7