### PR TITLE
Develop 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.eggy03</groupId>
     <artifactId>papertrailbot</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.1</version>
     <name>PaperTrail Bot</name>
     <description>A simple bot for logging all server and member actions</description>
     <packaging>quarkus</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.eggy03</groupId>
     <artifactId>papertrailbot</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.1-SNAPSHOT</version>
     <name>PaperTrail Bot</name>
     <description>A simple bot for logging all server and member actions</description>
     <packaging>quarkus</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
         <!-- Dependency Versions -->
         <jda.version>6.4.1</jda.version>
-        <papertrail.sdk.version>2.0.5</papertrail.sdk.version>
+        <papertrail.sdk.version>3.0.0</papertrail.sdk.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <guava.version>33.5.0-jre</guava.version>
         <jetbrains.annotations.version>26.1.0</jetbrains.annotations.version>
@@ -52,6 +52,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
         </dependency>
 
         <!-- Health -->

--- a/src/main/java/io/github/eggy03/papertrail/bot/bean/PaperTrailSdkBeanProvider.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/bean/PaperTrailSdkBeanProvider.java
@@ -1,5 +1,6 @@
 package io.github.eggy03.papertrail.bot.bean;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.client.MessageLogContentClient;
 import io.github.eggy03.papertrail.sdk.client.MessageLogRegistrationClient;
@@ -14,30 +15,32 @@ import org.jetbrains.annotations.Contract;
 public final class PaperTrailSdkBeanProvider {
 
     private final @NonNull String apiUrl;
+    private final @NonNull ObjectMapper objectMapper;
 
     @Inject
-    public PaperTrailSdkBeanProvider(@ConfigProperty(name = "api.url") @NonNull String apiUrl) {
+    public PaperTrailSdkBeanProvider(@ConfigProperty(name = "api.url") @NonNull String apiUrl, @NonNull ObjectMapper objectMapper) {
         this.apiUrl = apiUrl;
+        this.objectMapper = objectMapper;
     }
 
     @Contract(" -> new")
     @Produces
     @ApplicationScoped
     public @NonNull AuditLogRegistrationClient auditLogRegistrationClient() {
-        return new AuditLogRegistrationClient(apiUrl);
+        return new AuditLogRegistrationClient(apiUrl, objectMapper);
     }
 
     @Contract(" -> new")
     @Produces
     @ApplicationScoped
     public @NonNull MessageLogRegistrationClient messageLogRegistrationClient() {
-        return new MessageLogRegistrationClient(apiUrl);
+        return new MessageLogRegistrationClient(apiUrl, objectMapper);
     }
 
     @Contract(" -> new")
     @Produces
     @ApplicationScoped
     public @NonNull MessageLogContentClient messageLogContentClient() {
-        return new MessageLogContentClient(apiUrl);
+        return new MessageLogContentClient(apiUrl, objectMapper);
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/constant/ProjectInfo.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/constant/ProjectInfo.java
@@ -10,7 +10,7 @@ public final class ProjectInfo {
     public static final String APPNAME = "PaperTrail";
 
     @NonNull
-    public static final String VERSION = "v4.1.0";
+    public static final String VERSION = "v4.1.1-SNAPSHOT";
 
     @NonNull
     public static final String PROJECT_ISSUE_LINK = "https://github.com/eggy03/PaperTrailBot/issues";

--- a/src/main/java/io/github/eggy03/papertrail/bot/constant/ProjectInfo.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/constant/ProjectInfo.java
@@ -10,7 +10,7 @@ public final class ProjectInfo {
     public static final String APPNAME = "PaperTrail";
 
     @NonNull
-    public static final String VERSION = "v4.1.1-SNAPSHOT";
+    public static final String VERSION = "v4.1.1";
 
     @NonNull
     public static final String PROJECT_ISSUE_LINK = "https://github.com/eggy03/PaperTrailBot/issues";

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/AutoModActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/AutoModActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.AutoModUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
@@ -23,12 +23,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class AutoModEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class AutoModActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public AutoModEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public AutoModActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ChannelActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ChannelActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.bot.utils.DurationUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.ChannelUtils;
@@ -24,12 +24,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class ChannelEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class ChannelActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public ChannelEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public ChannelActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ChannelOverrideActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ChannelOverrideActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.auditlog.ChannelUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
@@ -24,12 +24,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class ChannelOverrideEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class ChannelOverrideActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public ChannelOverrideEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public ChannelOverrideActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/EmojiActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/EmojiActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,12 +20,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class IntegrationEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class EmojiActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public IntegrationEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public EmojiActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 
@@ -49,7 +49,7 @@ public final class IntegrationEventHandler extends GuildAuditLogEntryCreateEvent
     }
 
     @Override
-    public void onIntegrationCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onEmojiCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -59,23 +59,21 @@ public final class IntegrationEventHandler extends GuildAuditLogEntryCreateEvent
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Integration Create Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Integration Created By: " + mentionableExecutor));
-        eb.setColor(Color.PINK);
+        eb.setTitle("Audit Log Entry | Emoji Create Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Emoji Created By: " + mentionableExecutor));
+        eb.setColor(Color.GREEN);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
 
             Object oldValue = changeValue.getOldValue();
             Object newValue = changeValue.getNewValue();
 
-            switch (changeKey) {
-                case "type" -> eb.addField(MarkdownUtil.underline("Integration Type"), "╰┈➤" + newValue, false);
-                case "name" -> eb.addField(MarkdownUtil.underline("Integration Name"), "╰┈➤" + newValue, false);
-
-                default -> {
-                    eb.addField("Unimplemented Change Key", changeKey, false);
-                    log.info("Unimplemented Change Key on Integration Create: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
-                }
+            if (changeKey.equals("name")) {
+                eb.addField(MarkdownUtil.underline("Emoji Name"), "╰┈➤" + newValue, false);
+                eb.addField(MarkdownUtil.underline("Emoji"), "╰┈➤" + "<:" + newValue + ":" + ale.getTargetId() + ">", false); // ale's TargetID retrieves the ID of the created emoji
+            } else {
+                eb.addField("Unimplemented Change Key", changeKey, false);
+                log.info("Unimplemented Change Key on Emoji Create: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
             }
         });
 
@@ -86,32 +84,7 @@ public final class IntegrationEventHandler extends GuildAuditLogEntryCreateEvent
     }
 
     @Override
-    public void onIntegrationUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
-
-        log.warn("Integration Update Event Detected. Implement this sometime later\n{}", event.getEntry().getChanges());
-
-        String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
-        if (channelIdToSendTo.isBlank()) return;
-
-        AuditLogEntry ale = event.getEntry();
-
-        EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Integration Update Event");
-        eb.setColor(Color.LIGHT_GRAY);
-
-        String implementationNotice = "We do not have sufficient data to log the changes in an INTEGRATION_UPDATE Event."
-                .concat(" A proper implementation might happen in future releases if such an event is fired consistently.");
-
-        eb.addField("Implementation Notice", MarkdownUtil.codeblock(implementationNotice), false);
-
-        eb.setFooter("Audit Log Entry ID: " + ale.getId());
-        eb.setTimestamp(ale.getTimeCreated());
-
-        performChecksThenBuildAndSendEmbed(event, eb, channelIdToSendTo);
-    }
-
-    @Override
-    public void onIntegrationDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onEmojiUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -120,23 +93,23 @@ public final class IntegrationEventHandler extends GuildAuditLogEntryCreateEvent
         User executor = ale.getJDA().getUserById(ale.getUserIdLong());
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
+
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Integration Delete Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Integration Deleted By: " + mentionableExecutor));
-        eb.setColor(Color.MAGENTA);
+        eb.setTitle("Audit Log Entry | Emoji Update Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Emoji Updated By: " + mentionableExecutor));
+        eb.setColor(Color.YELLOW);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
+
             Object oldValue = changeValue.getOldValue();
             Object newValue = changeValue.getNewValue();
 
-            switch (changeKey) {
-                case "type" -> eb.addField(MarkdownUtil.underline("Integration Type"), "╰┈➤" + oldValue, false);
-                case "name" -> eb.addField(MarkdownUtil.underline("Integration Name"), "╰┈➤" + oldValue, false);
-
-                default -> {
-                    eb.addField("Unimplemented Change Key", changeKey, false);
-                    log.info("Unimplemented Change Key on Integration Delete: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
-                }
+            if (changeKey.equals("name")) {
+                eb.addField(MarkdownUtil.underline("Emoji Name Updated"), "╰┈➤" + "From " + oldValue + " to " + newValue, false);
+                eb.addField(MarkdownUtil.underline("Target Emoji"), "╰┈➤" + "<:" + newValue + ":" + ale.getTargetId() + ">", false);
+            } else {
+                eb.addField("Unimplemented Change Key", changeKey, false);
+                log.info("Unimplemented Change Key on Emoji Update: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
             }
         });
 
@@ -147,7 +120,7 @@ public final class IntegrationEventHandler extends GuildAuditLogEntryCreateEvent
     }
 
     @Override
-    public void onApplicationCommandPrivilegesUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onEmojiDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -157,11 +130,23 @@ public final class IntegrationEventHandler extends GuildAuditLogEntryCreateEvent
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Application Command Privilege Update");
-        eb.setDescription(MarkdownUtil.quoteBlock("Application Command Privilege Updated By: " + mentionableExecutor));
-        eb.setColor(Color.PINK);
+        eb.setTitle("Audit Log Entry | Emoji Delete Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Emoji Deleted By: " + mentionableExecutor));
+        eb.setColor(Color.RED);
 
-        eb.addField(MarkdownUtil.underline("More Info"), MarkdownUtil.codeblock("To know more about what changes were made, visit the Integrations section"), false);
+        ale.getChanges().forEach((changeKey, changeValue) -> {
+
+            Object oldValue = changeValue.getOldValue();
+            Object newValue = changeValue.getNewValue();
+
+            if (changeKey.equals("name")) {
+                eb.addField(MarkdownUtil.underline("Emoji Name"), "╰┈➤" + oldValue, false);
+            } else {
+                eb.addField("Unimplemented Change Key", changeKey, false);
+                log.info("Unimplemented Change Key on Emoji Delete: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+            }
+        });
+        eb.addField("Deleted Emoji ID", "╰┈➤" + ale.getTargetId(), false);
 
         eb.setFooter("Audit Log Entry ID: " + ale.getId());
         eb.setTimestamp(ale.getTimeCreated());

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/GuildUpdateActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/GuildUpdateActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.bot.utils.DurationUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.GuildUtils;
@@ -23,12 +23,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class GuildUpdateEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class GuildUpdateActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public GuildUpdateEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public GuildUpdateActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/HomeSettingsActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/HomeSettingsActionTypeHandler.java
@@ -1,7 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
-import io.github.eggy03.papertrail.bot.utils.auditlog.MessageUtils;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -21,12 +20,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class MessagePinEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class HomeSettingsActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public MessagePinEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public HomeSettingsActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 
@@ -50,27 +49,23 @@ public final class MessagePinEventHandler extends GuildAuditLogEntryCreateEventH
     }
 
     @Override
-    public void onMessagePin(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onHomeSettingsCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
         AuditLogEntry ale = event.getEntry();
 
-        EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Message Pin Event");
-
-        User executor = ale.getJDA().getUserById(ale.getUserId());
+        User executor = ale.getJDA().getUserById(ale.getUserIdLong());
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
-        User target = ale.getJDA().getUserById(ale.getTargetId());
-        String mentionableTarget = (target != null ? target.getAsMention() : ale.getTargetId());
-
-        eb.setDescription(MarkdownUtil.quoteBlock("Message Pinned By: " + mentionableExecutor + "\nMessage Author: " + mentionableTarget));
-        eb.setColor(Color.PINK);
+        EmbedBuilder eb = new EmbedBuilder();
+        eb.setTitle("Audit Log Entry | Server Guide Create Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Server Guide Created By: " + mentionableExecutor));
+        eb.setColor(Color.GREEN);
 
         eb.addField(
-                MarkdownUtil.underline("Pinned Message Jump URL"),
-                MessageUtils.resolveMessageJumpUrlFromId(ale.getOptionByName("channel_id"), ale.getOptionByName("message_id"), event),
+                MarkdownUtil.underline("More Info"),
+                MarkdownUtil.codeblock("To view the created guide, either visit the Server Guide section or the Onboarding section of your guild."),
                 false
         );
 
@@ -81,29 +76,31 @@ public final class MessagePinEventHandler extends GuildAuditLogEntryCreateEventH
     }
 
     @Override
-    public void onMessageUnpin(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onHomeSettingsUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
         AuditLogEntry ale = event.getEntry();
 
-        EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Message Unpin Event");
-
-        User executor = ale.getJDA().getUserById(ale.getUserId());
+        User executor = ale.getJDA().getUserById(ale.getUserIdLong());
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
-        User target = ale.getJDA().getUserById(ale.getTargetId());
-        String mentionableTarget = (target != null ? target.getAsMention() : ale.getTargetId());
+        EmbedBuilder eb = new EmbedBuilder();
+        eb.setTitle("Audit Log Entry | Server Guide Update Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Server Guide Updated By: " + mentionableExecutor));
+        eb.setColor(Color.YELLOW);
 
-        eb.setDescription(MarkdownUtil.quoteBlock("Message Un-Pinned By: " + mentionableExecutor + "\nMessage Author: " + mentionableTarget));
-        eb.setColor(Color.MAGENTA);
-
-        eb.addField(
-                MarkdownUtil.underline("Un-Pinned Message Jump URL"),
-                MessageUtils.resolveMessageJumpUrlFromId(ale.getOptionByName("channel_id"), ale.getOptionByName("message_id"), event),
-                false
-        );
+        ale.getChanges().keySet().forEach(key -> {
+            switch (key) {
+                case "welcome_message" ->
+                        eb.addField(MarkdownUtil.underline("Welcome Message"), "╰┈➤Welcome Message has been updated", false);
+                case "resource_channels" ->
+                        eb.addField(MarkdownUtil.underline("Resources"), "╰┈➤Resources have been updated", false);
+                case "new_member_actions" ->
+                        eb.addField(MarkdownUtil.underline("New Member Join To-Do"), "╰┈➤Interactive Actions have been updated", false);
+                default -> eb.addField(MarkdownUtil.underline(key), "╰┈➤" + key + " has/have been updated", false);
+            }
+        });
 
         eb.setFooter("Audit Log Entry ID: " + ale.getId());
         eb.setTimestamp(ale.getTimeCreated());

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/IntegrationActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/IntegrationActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,12 +20,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class EmojiEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class IntegrationActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public EmojiEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public IntegrationActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 
@@ -49,7 +49,7 @@ public final class EmojiEventHandler extends GuildAuditLogEntryCreateEventHandle
     }
 
     @Override
-    public void onEmojiCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onIntegrationCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -59,21 +59,23 @@ public final class EmojiEventHandler extends GuildAuditLogEntryCreateEventHandle
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Emoji Create Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Emoji Created By: " + mentionableExecutor));
-        eb.setColor(Color.GREEN);
+        eb.setTitle("Audit Log Entry | Integration Create Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Integration Created By: " + mentionableExecutor));
+        eb.setColor(Color.PINK);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
 
             Object oldValue = changeValue.getOldValue();
             Object newValue = changeValue.getNewValue();
 
-            if (changeKey.equals("name")) {
-                eb.addField(MarkdownUtil.underline("Emoji Name"), "╰┈➤" + newValue, false);
-                eb.addField(MarkdownUtil.underline("Emoji"), "╰┈➤" + "<:" + newValue + ":" + ale.getTargetId() + ">", false); // ale's TargetID retrieves the ID of the created emoji
-            } else {
-                eb.addField("Unimplemented Change Key", changeKey, false);
-                log.info("Unimplemented Change Key on Emoji Create: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+            switch (changeKey) {
+                case "type" -> eb.addField(MarkdownUtil.underline("Integration Type"), "╰┈➤" + newValue, false);
+                case "name" -> eb.addField(MarkdownUtil.underline("Integration Name"), "╰┈➤" + newValue, false);
+
+                default -> {
+                    eb.addField("Unimplemented Change Key", changeKey, false);
+                    log.info("Unimplemented Change Key on Integration Create: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+                }
             }
         });
 
@@ -84,7 +86,32 @@ public final class EmojiEventHandler extends GuildAuditLogEntryCreateEventHandle
     }
 
     @Override
-    public void onEmojiUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onIntegrationUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
+
+        log.warn("Integration Update Event Detected. Implement this sometime later\n{}", event.getEntry().getChanges());
+
+        String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
+        if (channelIdToSendTo.isBlank()) return;
+
+        AuditLogEntry ale = event.getEntry();
+
+        EmbedBuilder eb = new EmbedBuilder();
+        eb.setTitle("Audit Log Entry | Integration Update Event");
+        eb.setColor(Color.LIGHT_GRAY);
+
+        String implementationNotice = "We do not have sufficient data to log the changes in an INTEGRATION_UPDATE Event."
+                .concat(" A proper implementation might happen in future releases if such an event is fired consistently.");
+
+        eb.addField("Implementation Notice", MarkdownUtil.codeblock(implementationNotice), false);
+
+        eb.setFooter("Audit Log Entry ID: " + ale.getId());
+        eb.setTimestamp(ale.getTimeCreated());
+
+        performChecksThenBuildAndSendEmbed(event, eb, channelIdToSendTo);
+    }
+
+    @Override
+    public void onIntegrationDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -93,23 +120,23 @@ public final class EmojiEventHandler extends GuildAuditLogEntryCreateEventHandle
         User executor = ale.getJDA().getUserById(ale.getUserIdLong());
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
-
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Emoji Update Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Emoji Updated By: " + mentionableExecutor));
-        eb.setColor(Color.YELLOW);
+        eb.setTitle("Audit Log Entry | Integration Delete Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Integration Deleted By: " + mentionableExecutor));
+        eb.setColor(Color.MAGENTA);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
-
             Object oldValue = changeValue.getOldValue();
             Object newValue = changeValue.getNewValue();
 
-            if (changeKey.equals("name")) {
-                eb.addField(MarkdownUtil.underline("Emoji Name Updated"), "╰┈➤" + "From " + oldValue + " to " + newValue, false);
-                eb.addField(MarkdownUtil.underline("Target Emoji"), "╰┈➤" + "<:" + newValue + ":" + ale.getTargetId() + ">", false);
-            } else {
-                eb.addField("Unimplemented Change Key", changeKey, false);
-                log.info("Unimplemented Change Key on Emoji Update: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+            switch (changeKey) {
+                case "type" -> eb.addField(MarkdownUtil.underline("Integration Type"), "╰┈➤" + oldValue, false);
+                case "name" -> eb.addField(MarkdownUtil.underline("Integration Name"), "╰┈➤" + oldValue, false);
+
+                default -> {
+                    eb.addField("Unimplemented Change Key", changeKey, false);
+                    log.info("Unimplemented Change Key on Integration Delete: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+                }
             }
         });
 
@@ -120,7 +147,7 @@ public final class EmojiEventHandler extends GuildAuditLogEntryCreateEventHandle
     }
 
     @Override
-    public void onEmojiDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onApplicationCommandPrivilegesUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -130,23 +157,11 @@ public final class EmojiEventHandler extends GuildAuditLogEntryCreateEventHandle
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Emoji Delete Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Emoji Deleted By: " + mentionableExecutor));
-        eb.setColor(Color.RED);
+        eb.setTitle("Audit Log Entry | Application Command Privilege Update");
+        eb.setDescription(MarkdownUtil.quoteBlock("Application Command Privilege Updated By: " + mentionableExecutor));
+        eb.setColor(Color.PINK);
 
-        ale.getChanges().forEach((changeKey, changeValue) -> {
-
-            Object oldValue = changeValue.getOldValue();
-            Object newValue = changeValue.getNewValue();
-
-            if (changeKey.equals("name")) {
-                eb.addField(MarkdownUtil.underline("Emoji Name"), "╰┈➤" + oldValue, false);
-            } else {
-                eb.addField("Unimplemented Change Key", changeKey, false);
-                log.info("Unimplemented Change Key on Emoji Delete: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
-            }
-        });
-        eb.addField("Deleted Emoji ID", "╰┈➤" + ale.getTargetId(), false);
+        eb.addField(MarkdownUtil.underline("More Info"), MarkdownUtil.codeblock("To know more about what changes were made, visit the Integrations section"), false);
 
         eb.setFooter("Audit Log Entry ID: " + ale.getId());
         eb.setTimestamp(ale.getTimeCreated());

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/InviteActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/InviteActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.bot.utils.DurationUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.InviteUtils;
@@ -23,12 +23,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class InviteEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class InviteActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public InviteEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public InviteActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/MemberUpdateActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/MemberUpdateActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.bot.utils.DurationUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.MemberUtils;
@@ -23,12 +23,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class MemberStatusEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class MemberUpdateActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public MemberStatusEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public MemberUpdateActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/MessageActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/MessageActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,12 +20,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class MessageEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class MessageActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public MessageEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public MessageActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/MessagePinActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/MessagePinActionTypeHandler.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
+import io.github.eggy03.papertrail.bot.utils.auditlog.MessageUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,7 +12,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.AuditLogEntry;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
-import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -21,12 +21,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class VoiceChannelStatusEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class MessagePinActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public VoiceChannelStatusEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public MessagePinActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 
@@ -50,31 +50,27 @@ public final class VoiceChannelStatusEventHandler extends GuildAuditLogEntryCrea
     }
 
     @Override
-    public void onVoiceChannelStatusUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onMessagePin(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
         AuditLogEntry ale = event.getEntry();
 
+        EmbedBuilder eb = new EmbedBuilder();
+        eb.setTitle("Audit Log Entry | Message Pin Event");
+
         User executor = ale.getJDA().getUserById(ale.getUserId());
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
-        GuildChannel targetChannel = ale.getJDA().getGuildChannelById(ale.getTargetId());
-        String mentionableTargetChannel = (targetChannel != null ? targetChannel.getAsMention() : ale.getTargetId());
+        User target = ale.getJDA().getUserById(ale.getTargetId());
+        String mentionableTarget = (target != null ? target.getAsMention() : ale.getTargetId());
 
-        EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Voice Channel Status Update");
-
-        eb.setDescription("A voice channel status has been updated");
-        eb.setColor(Color.YELLOW);
+        eb.setDescription(MarkdownUtil.quoteBlock("Message Pinned By: " + mentionableExecutor + "\nMessage Author: " + mentionableTarget));
+        eb.setColor(Color.PINK);
 
         eb.addField(
-                MarkdownUtil.underline("Details"),
-                MarkdownUtil.quoteBlock(
-                        "Status Updated By: " + mentionableExecutor + "\n" +
-                                "Target Channel: " + mentionableTargetChannel + "\n" +
-                                "Updated Status: " + ale.getOptionByName("status")
-                ),
+                MarkdownUtil.underline("Pinned Message Jump URL"),
+                MessageUtils.resolveMessageJumpUrlFromId(ale.getOptionByName("channel_id"), ale.getOptionByName("message_id"), event),
                 false
         );
 
@@ -85,28 +81,27 @@ public final class VoiceChannelStatusEventHandler extends GuildAuditLogEntryCrea
     }
 
     @Override
-    public void onVoiceChannelStatusDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onMessageUnpin(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
         AuditLogEntry ale = event.getEntry();
 
+        EmbedBuilder eb = new EmbedBuilder();
+        eb.setTitle("Audit Log Entry | Message Unpin Event");
+
         User executor = ale.getJDA().getUserById(ale.getUserId());
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
-        GuildChannel targetChannel = ale.getJDA().getGuildChannelById(ale.getTargetId());
-        String mentionableTargetChannel = (targetChannel != null ? targetChannel.getAsMention() : ale.getTargetId());
+        User target = ale.getJDA().getUserById(ale.getTargetId());
+        String mentionableTarget = (target != null ? target.getAsMention() : ale.getTargetId());
 
-        EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Voice Channel Status Delete");
+        eb.setDescription(MarkdownUtil.quoteBlock("Message Un-Pinned By: " + mentionableExecutor + "\nMessage Author: " + mentionableTarget));
+        eb.setColor(Color.MAGENTA);
 
-        eb.setDescription("A voice channel status has been reset");
-        eb.setColor(Color.ORANGE);
-
-        // status deletes dont contain the deleted status content
         eb.addField(
-                MarkdownUtil.underline("Details"),
-                MarkdownUtil.quoteBlock("Status Reset By: " + mentionableExecutor + "\n" + "Target Channel: " + mentionableTargetChannel),
+                MarkdownUtil.underline("Un-Pinned Message Jump URL"),
+                MessageUtils.resolveMessageJumpUrlFromId(ale.getOptionByName("channel_id"), ale.getOptionByName("message_id"), event),
                 false
         );
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ModActionActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ModActionActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,12 +20,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class ModActionEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class ModActionActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public ModActionEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public ModActionActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/OnboardingActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/OnboardingActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.OnboardingUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
@@ -23,12 +23,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class OnboardingEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class OnboardingActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public OnboardingEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public OnboardingActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/OnboardingPromptActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/OnboardingPromptActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
@@ -21,12 +21,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class OnboardingPromptEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class OnboardingPromptActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public OnboardingPromptEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public OnboardingPromptActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/RoleActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/RoleActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.RoleUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
@@ -23,12 +23,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class RoleEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class RoleActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public RoleEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public RoleActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ScheduledEventActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ScheduledEventActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.auditlog.ScheduledEventUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
@@ -21,12 +21,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class ScheduledEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class ScheduledEventActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public ScheduledEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public ScheduledEventActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/SoundboardActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/SoundboardActionTypeHandler.java
@@ -1,7 +1,7 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
-import io.github.eggy03.papertrail.bot.utils.auditlog.StageUtils;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
+import io.github.eggy03.papertrail.bot.utils.auditlog.SoundboardUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -21,12 +21,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class StageInstanceEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class SoundboardActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public StageInstanceEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public SoundboardActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 
@@ -50,7 +50,7 @@ public final class StageInstanceEventHandler extends GuildAuditLogEntryCreateEve
     }
 
     @Override
-    public void onStageInstanceCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onSoundboardSoundCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -60,23 +60,32 @@ public final class StageInstanceEventHandler extends GuildAuditLogEntryCreateEve
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Stage Instance Create Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Stage Instance Created By: " + mentionableExecutor));
+        eb.setTitle("Audit Log Entry | Soundboard Sound Create Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Sound Item Added By: " + mentionableExecutor));
         eb.setColor(Color.GREEN);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
+
             Object oldValue = changeValue.getOldValue();
             Object newValue = changeValue.getNewValue();
 
             switch (changeKey) {
-                case "topic" -> eb.addField(MarkdownUtil.underline("Stage Topic"), "╰┈➤" + newValue, false);
 
-                case "privacy_level" ->
-                        eb.addField(MarkdownUtil.underline("Stage Privacy"), "╰┈➤" + StageUtils.resolveStagePrivacyLevel(newValue), false);
+                case "user_id", "sound_id", "id", "guild_id", "available" -> {
+                    // skip
+                }
+                case "volume" ->
+                        eb.addField(MarkdownUtil.underline("Volume"), "╰┈➤" + SoundboardUtils.resolveVolumePercentage(newValue), false);
+
+                case "emoji_name" -> eb.addField(MarkdownUtil.underline("Related Emoji"), "╰┈➤" + newValue, false);
+
+                case "emoji_id" -> eb.addField(MarkdownUtil.underline("Related Emoji ID"), "╰┈➤" + newValue, false);
+
+                case "name" -> eb.addField(MarkdownUtil.underline("Sound Item Name"), "╰┈➤" + newValue, false);
 
                 default -> {
                     eb.addField("Unimplemented Change Key", changeKey, false);
-                    log.info("Unimplemented Change Key on Stage Instance Create: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+                    log.info("Unimplemented Change Key on Soundboard Sound Create: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
                 }
             }
         });
@@ -88,7 +97,7 @@ public final class StageInstanceEventHandler extends GuildAuditLogEntryCreateEve
     }
 
     @Override
-    public void onStageInstanceUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onSoundboardSoundUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -98,8 +107,8 @@ public final class StageInstanceEventHandler extends GuildAuditLogEntryCreateEve
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Stage Instance Update Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Stage Instance Updated By: " + mentionableExecutor));
+        eb.setTitle("Audit Log Entry | Soundboard Sound Update Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Sound Item Updated By: " + mentionableExecutor));
         eb.setColor(Color.YELLOW);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
@@ -107,20 +116,32 @@ public final class StageInstanceEventHandler extends GuildAuditLogEntryCreateEve
             Object newValue = changeValue.getNewValue();
 
             switch (changeKey) {
-                case "topic" -> {
-                    eb.addField(MarkdownUtil.underline("Old Stage Topic"), "╰┈➤" + oldValue, true);
-                    eb.addField(MarkdownUtil.underline("New Stage Topic"), "╰┈➤" + newValue, true);
+                case "user_id", "sound_id", "id", "guild_id", "available" -> {
+                    // skip
+                }
+                case "volume" -> {
+                    eb.addField(MarkdownUtil.underline("Old Volume"), "╰┈➤" + SoundboardUtils.resolveVolumePercentage(oldValue), true);
+                    eb.addField(MarkdownUtil.underline("New Volume"), "╰┈➤" + SoundboardUtils.resolveVolumePercentage(newValue), true);
                     eb.addBlankField(true);
                 }
-                case "privacy_level" -> {
-                    eb.addField(MarkdownUtil.underline("Old Stage Privacy"), "╰┈➤" + StageUtils.resolveStagePrivacyLevel(oldValue), true);
-                    eb.addField(MarkdownUtil.underline("New Stage Privacy"), "╰┈➤" + StageUtils.resolveStagePrivacyLevel(newValue), true);
+                case "emoji_name" -> {
+                    eb.addField(MarkdownUtil.underline("Old Related Emoji"), "╰┈➤" + oldValue, true);
+                    eb.addField(MarkdownUtil.underline("New Related Emoji"), "╰┈➤" + newValue, true);
                     eb.addBlankField(true);
                 }
-
+                case "emoji_id" -> {
+                    eb.addField(MarkdownUtil.underline("Old Related Emoji ID"), "╰┈➤" + oldValue, true);
+                    eb.addField(MarkdownUtil.underline("New Related Emoji ID"), "╰┈➤" + newValue, true);
+                    eb.addBlankField(true);
+                }
+                case "name" -> {
+                    eb.addField(MarkdownUtil.underline("Old Sound Item Name"), "╰┈➤" + oldValue, true);
+                    eb.addField(MarkdownUtil.underline("New Sound Item Name"), "╰┈➤" + newValue, true);
+                    eb.addBlankField(true);
+                }
                 default -> {
                     eb.addField("Unimplemented Change Key", changeKey, false);
-                    log.info("Unimplemented Change Key on Stage Instance Update: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+                    log.info("Unimplemented Change Key on Soundboard Sound Update: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
                 }
             }
         });
@@ -132,7 +153,7 @@ public final class StageInstanceEventHandler extends GuildAuditLogEntryCreateEve
     }
 
     @Override
-    public void onStageInstanceDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onSoundboardSoundDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -142,26 +163,36 @@ public final class StageInstanceEventHandler extends GuildAuditLogEntryCreateEve
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Stage Instance Delete Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Stage Instance Deleted By: " + mentionableExecutor));
+        eb.setTitle("Audit Log Entry | Soundboard Sound Delete Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Sound Item Deleted By: " + mentionableExecutor));
         eb.setColor(Color.RED);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
+
             Object oldValue = changeValue.getOldValue();
             Object newValue = changeValue.getNewValue();
 
             switch (changeKey) {
-                case "topic" -> eb.addField(MarkdownUtil.underline("Stage Topic"), "╰┈➤" + oldValue, false);
 
-                case "privacy_level" ->
-                        eb.addField(MarkdownUtil.underline("Stage Privacy"), "╰┈➤" + StageUtils.resolveStagePrivacyLevel(oldValue), false);
+                case "user_id", "sound_id", "id", "guild_id", "available" -> {
+                    // skip
+                }
+                case "volume" ->
+                        eb.addField(MarkdownUtil.underline("Volume"), "╰┈➤" + SoundboardUtils.resolveVolumePercentage(oldValue), false);
+
+                case "emoji_name" -> eb.addField(MarkdownUtil.underline("Related Emoji"), "╰┈➤" + oldValue, false);
+
+                case "emoji_id" -> eb.addField(MarkdownUtil.underline("Related Emoji ID"), "╰┈➤" + oldValue, false);
+
+                case "name" -> eb.addField(MarkdownUtil.underline("Sound Item Name"), "╰┈➤" + oldValue, false);
 
                 default -> {
                     eb.addField("Unimplemented Change Key", changeKey, false);
-                    log.info("Unimplemented Change Key on Stage Instance Delete: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+                    log.info("Unimplemented Change Key on Soundboard Sound Delete: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
                 }
             }
         });
+
         eb.setFooter("Audit Log Entry ID: " + ale.getId());
         eb.setTimestamp(ale.getTimeCreated());
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/StageInstanceActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/StageInstanceActionTypeHandler.java
@@ -1,7 +1,7 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
-import io.github.eggy03.papertrail.bot.utils.auditlog.SoundboardUtils;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
+import io.github.eggy03.papertrail.bot.utils.auditlog.StageUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -21,12 +21,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class SoundboardEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class StageInstanceActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public SoundboardEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public StageInstanceActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 
@@ -50,7 +50,7 @@ public final class SoundboardEventHandler extends GuildAuditLogEntryCreateEventH
     }
 
     @Override
-    public void onSoundboardSoundCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onStageInstanceCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -60,32 +60,23 @@ public final class SoundboardEventHandler extends GuildAuditLogEntryCreateEventH
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Soundboard Sound Create Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Sound Item Added By: " + mentionableExecutor));
+        eb.setTitle("Audit Log Entry | Stage Instance Create Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Stage Instance Created By: " + mentionableExecutor));
         eb.setColor(Color.GREEN);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
-
             Object oldValue = changeValue.getOldValue();
             Object newValue = changeValue.getNewValue();
 
             switch (changeKey) {
+                case "topic" -> eb.addField(MarkdownUtil.underline("Stage Topic"), "╰┈➤" + newValue, false);
 
-                case "user_id", "sound_id", "id", "guild_id", "available" -> {
-                    // skip
-                }
-                case "volume" ->
-                        eb.addField(MarkdownUtil.underline("Volume"), "╰┈➤" + SoundboardUtils.resolveVolumePercentage(newValue), false);
-
-                case "emoji_name" -> eb.addField(MarkdownUtil.underline("Related Emoji"), "╰┈➤" + newValue, false);
-
-                case "emoji_id" -> eb.addField(MarkdownUtil.underline("Related Emoji ID"), "╰┈➤" + newValue, false);
-
-                case "name" -> eb.addField(MarkdownUtil.underline("Sound Item Name"), "╰┈➤" + newValue, false);
+                case "privacy_level" ->
+                        eb.addField(MarkdownUtil.underline("Stage Privacy"), "╰┈➤" + StageUtils.resolveStagePrivacyLevel(newValue), false);
 
                 default -> {
                     eb.addField("Unimplemented Change Key", changeKey, false);
-                    log.info("Unimplemented Change Key on Soundboard Sound Create: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+                    log.info("Unimplemented Change Key on Stage Instance Create: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
                 }
             }
         });
@@ -97,7 +88,7 @@ public final class SoundboardEventHandler extends GuildAuditLogEntryCreateEventH
     }
 
     @Override
-    public void onSoundboardSoundUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onStageInstanceUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -107,8 +98,8 @@ public final class SoundboardEventHandler extends GuildAuditLogEntryCreateEventH
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Soundboard Sound Update Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Sound Item Updated By: " + mentionableExecutor));
+        eb.setTitle("Audit Log Entry | Stage Instance Update Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Stage Instance Updated By: " + mentionableExecutor));
         eb.setColor(Color.YELLOW);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
@@ -116,32 +107,20 @@ public final class SoundboardEventHandler extends GuildAuditLogEntryCreateEventH
             Object newValue = changeValue.getNewValue();
 
             switch (changeKey) {
-                case "user_id", "sound_id", "id", "guild_id", "available" -> {
-                    // skip
-                }
-                case "volume" -> {
-                    eb.addField(MarkdownUtil.underline("Old Volume"), "╰┈➤" + SoundboardUtils.resolveVolumePercentage(oldValue), true);
-                    eb.addField(MarkdownUtil.underline("New Volume"), "╰┈➤" + SoundboardUtils.resolveVolumePercentage(newValue), true);
+                case "topic" -> {
+                    eb.addField(MarkdownUtil.underline("Old Stage Topic"), "╰┈➤" + oldValue, true);
+                    eb.addField(MarkdownUtil.underline("New Stage Topic"), "╰┈➤" + newValue, true);
                     eb.addBlankField(true);
                 }
-                case "emoji_name" -> {
-                    eb.addField(MarkdownUtil.underline("Old Related Emoji"), "╰┈➤" + oldValue, true);
-                    eb.addField(MarkdownUtil.underline("New Related Emoji"), "╰┈➤" + newValue, true);
+                case "privacy_level" -> {
+                    eb.addField(MarkdownUtil.underline("Old Stage Privacy"), "╰┈➤" + StageUtils.resolveStagePrivacyLevel(oldValue), true);
+                    eb.addField(MarkdownUtil.underline("New Stage Privacy"), "╰┈➤" + StageUtils.resolveStagePrivacyLevel(newValue), true);
                     eb.addBlankField(true);
                 }
-                case "emoji_id" -> {
-                    eb.addField(MarkdownUtil.underline("Old Related Emoji ID"), "╰┈➤" + oldValue, true);
-                    eb.addField(MarkdownUtil.underline("New Related Emoji ID"), "╰┈➤" + newValue, true);
-                    eb.addBlankField(true);
-                }
-                case "name" -> {
-                    eb.addField(MarkdownUtil.underline("Old Sound Item Name"), "╰┈➤" + oldValue, true);
-                    eb.addField(MarkdownUtil.underline("New Sound Item Name"), "╰┈➤" + newValue, true);
-                    eb.addBlankField(true);
-                }
+
                 default -> {
                     eb.addField("Unimplemented Change Key", changeKey, false);
-                    log.info("Unimplemented Change Key on Soundboard Sound Update: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+                    log.info("Unimplemented Change Key on Stage Instance Update: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
                 }
             }
         });
@@ -153,7 +132,7 @@ public final class SoundboardEventHandler extends GuildAuditLogEntryCreateEventH
     }
 
     @Override
-    public void onSoundboardSoundDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onStageInstanceDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
@@ -163,36 +142,26 @@ public final class SoundboardEventHandler extends GuildAuditLogEntryCreateEventH
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Soundboard Sound Delete Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Sound Item Deleted By: " + mentionableExecutor));
+        eb.setTitle("Audit Log Entry | Stage Instance Delete Event");
+        eb.setDescription(MarkdownUtil.quoteBlock("Stage Instance Deleted By: " + mentionableExecutor));
         eb.setColor(Color.RED);
 
         ale.getChanges().forEach((changeKey, changeValue) -> {
-
             Object oldValue = changeValue.getOldValue();
             Object newValue = changeValue.getNewValue();
 
             switch (changeKey) {
+                case "topic" -> eb.addField(MarkdownUtil.underline("Stage Topic"), "╰┈➤" + oldValue, false);
 
-                case "user_id", "sound_id", "id", "guild_id", "available" -> {
-                    // skip
-                }
-                case "volume" ->
-                        eb.addField(MarkdownUtil.underline("Volume"), "╰┈➤" + SoundboardUtils.resolveVolumePercentage(oldValue), false);
-
-                case "emoji_name" -> eb.addField(MarkdownUtil.underline("Related Emoji"), "╰┈➤" + oldValue, false);
-
-                case "emoji_id" -> eb.addField(MarkdownUtil.underline("Related Emoji ID"), "╰┈➤" + oldValue, false);
-
-                case "name" -> eb.addField(MarkdownUtil.underline("Sound Item Name"), "╰┈➤" + oldValue, false);
+                case "privacy_level" ->
+                        eb.addField(MarkdownUtil.underline("Stage Privacy"), "╰┈➤" + StageUtils.resolveStagePrivacyLevel(oldValue), false);
 
                 default -> {
                     eb.addField("Unimplemented Change Key", changeKey, false);
-                    log.info("Unimplemented Change Key on Soundboard Sound Delete: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
+                    log.info("Unimplemented Change Key on Stage Instance Delete: {}\nOLD_VALUE: {}\nNEW_VALUE: {}", changeKey, oldValue, newValue);
                 }
             }
         });
-
         eb.setFooter("Audit Log Entry ID: " + ale.getId());
         eb.setTimestamp(ale.getTimeCreated());
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/StickerActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/StickerActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.auditlog.StickerUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
@@ -22,12 +22,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class StickerEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class StickerActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public StickerEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public StickerActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ThreadActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ThreadActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.bot.utils.DurationUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.ChannelUtils;
@@ -25,12 +25,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class ThreadEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class ThreadActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public ThreadEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public ThreadActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/UnimplementedActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/UnimplementedActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import jakarta.enterprise.context.ApplicationScoped;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -10,10 +10,10 @@ import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class UnimplementedEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class UnimplementedActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     @Override
-    public void onUnimplementedEvent(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onUnimplementedActionType(@NonNull GuildAuditLogEntryCreateEvent event) {
         log.warn("Unimplemented Action Type: {} with Target Type: {}", event.getEntry().getType(), event.getEntry().getType().getTargetType());
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/UnknownActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/UnknownActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -21,12 +21,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class UnknownEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class UnknownActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public UnknownEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public UnknownActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 
@@ -50,7 +50,7 @@ public final class UnknownEventHandler extends GuildAuditLogEntryCreateEventHand
     }
 
     @Override
-    public void onUnknownEvent(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onUnknownActionType(@NonNull GuildAuditLogEntryCreateEvent event) {
 
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/VoiceChannelStatusActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/VoiceChannelStatusActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.AuditLogEntry;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -20,12 +21,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class HomeSettingsEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class VoiceChannelStatusActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public HomeSettingsEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public VoiceChannelStatusActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 
@@ -49,23 +50,31 @@ public final class HomeSettingsEventHandler extends GuildAuditLogEntryCreateEven
     }
 
     @Override
-    public void onHomeSettingsCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onVoiceChannelStatusUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
         AuditLogEntry ale = event.getEntry();
 
-        User executor = ale.getJDA().getUserById(ale.getUserIdLong());
+        User executor = ale.getJDA().getUserById(ale.getUserId());
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
+        GuildChannel targetChannel = ale.getJDA().getGuildChannelById(ale.getTargetId());
+        String mentionableTargetChannel = (targetChannel != null ? targetChannel.getAsMention() : ale.getTargetId());
+
         EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Server Guide Create Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Server Guide Created By: " + mentionableExecutor));
-        eb.setColor(Color.GREEN);
+        eb.setTitle("Audit Log Entry | Voice Channel Status Update");
+
+        eb.setDescription("A voice channel status has been updated");
+        eb.setColor(Color.YELLOW);
 
         eb.addField(
-                MarkdownUtil.underline("More Info"),
-                MarkdownUtil.codeblock("To view the created guide, either visit the Server Guide section or the Onboarding section of your guild."),
+                MarkdownUtil.underline("Details"),
+                MarkdownUtil.quoteBlock(
+                        "Status Updated By: " + mentionableExecutor + "\n" +
+                                "Target Channel: " + mentionableTargetChannel + "\n" +
+                                "Updated Status: " + ale.getOptionByName("status")
+                ),
                 false
         );
 
@@ -76,31 +85,30 @@ public final class HomeSettingsEventHandler extends GuildAuditLogEntryCreateEven
     }
 
     @Override
-    public void onHomeSettingsUpdate(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onVoiceChannelStatusDelete(@NonNull GuildAuditLogEntryCreateEvent event) {
         String channelIdToSendTo = getRegisteredGuildChannel(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
 
         AuditLogEntry ale = event.getEntry();
 
-        User executor = ale.getJDA().getUserById(ale.getUserIdLong());
+        User executor = ale.getJDA().getUserById(ale.getUserId());
         String mentionableExecutor = (executor != null ? executor.getAsMention() : ale.getUserId());
 
-        EmbedBuilder eb = new EmbedBuilder();
-        eb.setTitle("Audit Log Entry | Server Guide Update Event");
-        eb.setDescription(MarkdownUtil.quoteBlock("Server Guide Updated By: " + mentionableExecutor));
-        eb.setColor(Color.YELLOW);
+        GuildChannel targetChannel = ale.getJDA().getGuildChannelById(ale.getTargetId());
+        String mentionableTargetChannel = (targetChannel != null ? targetChannel.getAsMention() : ale.getTargetId());
 
-        ale.getChanges().keySet().forEach(key -> {
-            switch (key) {
-                case "welcome_message" ->
-                        eb.addField(MarkdownUtil.underline("Welcome Message"), "╰┈➤Welcome Message has been updated", false);
-                case "resource_channels" ->
-                        eb.addField(MarkdownUtil.underline("Resources"), "╰┈➤Resources have been updated", false);
-                case "new_member_actions" ->
-                        eb.addField(MarkdownUtil.underline("New Member Join To-Do"), "╰┈➤Interactive Actions have been updated", false);
-                default -> eb.addField(MarkdownUtil.underline(key), "╰┈➤" + key + " has/have been updated", false);
-            }
-        });
+        EmbedBuilder eb = new EmbedBuilder();
+        eb.setTitle("Audit Log Entry | Voice Channel Status Delete");
+
+        eb.setDescription("A voice channel status has been reset");
+        eb.setColor(Color.ORANGE);
+
+        // status deletes dont contain the deleted status content
+        eb.addField(
+                MarkdownUtil.underline("Details"),
+                MarkdownUtil.quoteBlock("Status Reset By: " + mentionableExecutor + "\n" + "Target Channel: " + mentionableTargetChannel),
+                false
+        );
 
         eb.setFooter("Audit Log Entry ID: " + ale.getId());
         eb.setTimestamp(ale.getTimeCreated());

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/WebhookActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/WebhookActionTypeHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.auditlog;
 
-import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventHandler;
+import io.github.eggy03.papertrail.bot.listeners.auditlog.GuildAuditLogEntryCreateEventActionTypeHandler;
 import io.github.eggy03.papertrail.bot.utils.auditlog.GuildUtils;
 import io.github.eggy03.papertrail.bot.utils.auditlog.WebhookUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
@@ -22,12 +22,12 @@ import java.awt.Color;
 @ApplicationScoped
 @Slf4j
 @SuppressWarnings("java:S1192")
-public final class WebhookEventHandler extends GuildAuditLogEntryCreateEventHandler {
+public final class WebhookActionTypeHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
 
     private final @NonNull AuditLogRegistrationClient client;
 
     @Inject
-    public WebhookEventHandler(@NonNull AuditLogRegistrationClient client) {
+    public WebhookActionTypeHandler(@NonNull AuditLogRegistrationClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryCreateEventActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryCreateEventActionTypeHandler.java
@@ -6,8 +6,8 @@ import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
 
 /**
  * <p>
- * Abstract base class for routing {@link GuildAuditLogEntryCreateEvent}
- * instances to their appropriate handler methods.
+ * Abstract base class for routing {@link GuildAuditLogEntryCreateEvent} {@link ActionType}
+ * to their appropriate handler methods.
  * Routing is performed by
  * {@link #handleActionType(GuildAuditLogEntryCreateEvent)}.
  * </p>
@@ -22,19 +22,19 @@ import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
  * </p>
  *
  * <p>
- * Subclasses may override only the event handlers they require. The
- * {@code handleEvent(...)} method is responsible for determining which
- * handler method should be invoked for a given audit log action.
+ * Subclasses may override only the action type handlers they require. The
+ * {@code handleActionType(...)} method is responsible for determining which
+ * handler method should be invoked for a given action type.
  * </p>
  *
  * <p>
  * If multiple subclasses are registered as CDI beans and are iterated
- * through {@code Instance<GuildAuditLogEntryCreateEventHandler>}, each handler
+ * through {@code Instance<GuildAuditLogEntryCreateEventActionTypeHandler>}, each handler
  * instance will independently receive and process the event.
  * </p>
  *
  * <p>
- * For example, if two subclasses override {@code onBan()}, both
+ * For example, if two subclasses override {@code onBan()} for processing BAN action types, both
  * implementations will be executed when a BAN audit log event is
  * processed, assuming both handler instances are iterated and invoked.
  * </p>
@@ -52,18 +52,17 @@ import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
  *
  * <pre>{@code
  * @ApplicationScoped
- * public class MyHandler extends GuildAuditLogEntryCreateEventHandler {
+ * public class MyHandler extends GuildAuditLogEntryCreateEventActionTypeHandler {
  *
  *     @Override
- *     public void onBan(@NonNull GuildAuditLogEntryCreateEvent event,
- *                       @NonNull String channelIdToSendTo) {
+ *     public void onBan(@NonNull GuildAuditLogEntryCreateEvent event) {
  *         // your logic here
  *     }
  * }
  * }</pre>
  *
  * <p>
- * Calling {@code handleEvent(...)} on {@code MyHandler} will
+ * Calling {@code handleActionType(...)} on {@code MyHandler} will
  * automatically route BAN audit log events to the overridden
  * {@code onBan()} method.
  * </p>
@@ -75,10 +74,10 @@ import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
  *
  * <pre>{@code
  * @Inject
- * Instance<GuildAuditLogEntryCreateEventHandler> eventHandlerInstance;
+ * Instance<GuildAuditLogEntryCreateEventActionTypeHandler> eventHandlerInstance;
  *
  * eventHandlerInstance.forEach(handler ->
- *     handler.handleEvent(event)
+ *     handler.handleActionType(event)
  * );
  * }</pre>
  *
@@ -87,7 +86,9 @@ import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
  * {@link GuildAuditLogEntryEventListener}.
  * </p>
  */
-public abstract class GuildAuditLogEntryCreateEventHandler {
+public abstract class GuildAuditLogEntryCreateEventActionTypeHandler {
+
+    // handler methods for ActionType
 
     public void onAutoModerationFlagToChannel(@NonNull GuildAuditLogEntryCreateEvent event) {
     }
@@ -297,21 +298,21 @@ public abstract class GuildAuditLogEntryCreateEventHandler {
     }
 
     /**
-     * For {@link ActionType} not fully known by JDA yet
+     * For {@link ActionType}s not defined in JDA yet
      */
-    public void onUnknownEvent(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onUnknownActionType(@NonNull GuildAuditLogEntryCreateEvent event) {
     }
 
     /**
-     * For {@link ActionType}s which are defined but not implemented by PaperTrail
+     * For {@link ActionType}s which are defined in JDA but not implemented by PaperTrail
      */
-    public void onUnimplementedEvent(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public void onUnimplementedActionType(@NonNull GuildAuditLogEntryCreateEvent event) {
     }
 
     /**
      * <p>
      * Routes a {@link GuildAuditLogEntryCreateEvent} to its corresponding
-     * event handler method based on the {@link ActionType} of the audit log entry.
+     * handler method based on the {@link ActionType} of the audit log entry.
      * </p>
      *
      * <p>
@@ -416,9 +417,9 @@ public abstract class GuildAuditLogEntryCreateEventHandler {
             case HOME_SETTINGS_CREATE -> onHomeSettingsCreate(event);
             case HOME_SETTINGS_UPDATE -> onHomeSettingsUpdate(event);
 
-            case UNKNOWN -> onUnknownEvent(event);
+            case UNKNOWN -> onUnknownActionType(event);
 
-            default -> onUnimplementedEvent(event);
+            default -> onUnimplementedActionType(event);
         }
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryCreateEventHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryCreateEventHandler.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
  * Abstract base class for routing {@link GuildAuditLogEntryCreateEvent}
  * instances to their appropriate handler methods.
  * Routing is performed by
- * {@link #handleEvent(GuildAuditLogEntryCreateEvent)}.
+ * {@link #handleActionType(GuildAuditLogEntryCreateEvent)}.
  * </p>
  *
  * <p>
@@ -315,16 +315,12 @@ public abstract class GuildAuditLogEntryCreateEventHandler {
      * </p>
      *
      * <p>
-     * Each event handler method can be overridden multiple times
-     * </p>
-     *
-     * <p>
      * This method is marked as {@code final} and cannot be overridden
      * </p>
      *
      * @param event             the audit log event received from JDA
      */
-    public final void handleEvent(@NonNull GuildAuditLogEntryCreateEvent event) {
+    public final void handleActionType(@NonNull GuildAuditLogEntryCreateEvent event) {
         ActionType action = event.getEntry().getType();
 
         switch (action) {

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
@@ -40,10 +40,10 @@ public final class GuildAuditLogEntryEventListener extends ListenerAdapter {
     @Override
     public void onGuildAuditLogEntryCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
 
-        Thread.ofVirtual()
+        guildAuditLogEntryCreateEventHandlers.forEach(handler -> Thread.ofVirtual()
                 .name("guild-audit-log-entry-create-event-listener-vthread-", 0)
-                .start(() -> guildAuditLogEntryCreateEventHandlers.forEach(handler -> handler.handleEvent(event))
-                );
+                .start(() -> handler.handleEvent(event))
+        );
     }
 
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
@@ -21,7 +21,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
  *
  * <p>
  * Each discovered handler instance will receive the event through
- * {@link GuildAuditLogEntryCreateEventHandler#handleEvent(GuildAuditLogEntryCreateEvent)}.
+ * {@link GuildAuditLogEntryCreateEventHandler#handleActionType(GuildAuditLogEntryCreateEvent)}.
  * This enables a multicast-style event processing pipeline where multiple
  * handler beans may react to the same audit log action independently.
  * </p>
@@ -40,9 +40,15 @@ public final class GuildAuditLogEntryEventListener extends ListenerAdapter {
     @Override
     public void onGuildAuditLogEntryCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
 
+        /*
+        Each handler gets its own virtual thread to handle the event
+        or else, the events will be processed sequentially in a single virtual thread.
+        This will be particularly slower if two or more inherited classes have overrides
+        for handling the same ActionType.
+         */
         guildAuditLogEntryCreateEventHandlers.forEach(handler -> Thread.ofVirtual()
                 .name("guild-audit-log-entry-create-event-listener-vthread-", 0)
-                .start(() -> handler.handleEvent(event))
+                .start(() -> handler.handleActionType(event))
         );
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
@@ -11,42 +11,41 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 /**
  * Listener responsible for receiving {@link GuildAuditLogEntryCreateEvent}
  * events from JDA and delegating them to all registered
- * {@link GuildAuditLogEntryCreateEventHandler} CDI beans.
+ * {@link GuildAuditLogEntryCreateEventActionTypeHandler} CDI beans.
  *
  * <p>
  * Event handlers are resolved dynamically using
- * {@code Instance<GuildAuditLogEntryCreateEventHandler>}, allowing multiple
+ * {@code Instance<GuildAuditLogEntryCreateEventActionTypeHandler>}, allowing multiple
  * independent handler implementations to process the same audit log event.
  * </p>
  *
  * <p>
  * Each discovered handler instance will receive the event through
- * {@link GuildAuditLogEntryCreateEventHandler#handleActionType(GuildAuditLogEntryCreateEvent)}.
- * This enables a multicast-style event processing pipeline where multiple
- * handler beans may react to the same audit log action independently.
+ * {@link GuildAuditLogEntryCreateEventActionTypeHandler#handleActionType(GuildAuditLogEntryCreateEvent)}, where
+ * it will process the event.
  * </p>
  */
 @Slf4j
 @ApplicationScoped
 public final class GuildAuditLogEntryEventListener extends ListenerAdapter {
 
-    private final @NonNull Instance<GuildAuditLogEntryCreateEventHandler> guildAuditLogEntryCreateEventHandlers;
+    private final @NonNull Instance<GuildAuditLogEntryCreateEventActionTypeHandler> handlerInstances;
 
     @Inject
-    public GuildAuditLogEntryEventListener(@NonNull Instance<GuildAuditLogEntryCreateEventHandler> guildAuditLogEntryCreateEventHandlers) {
-        this.guildAuditLogEntryCreateEventHandlers = guildAuditLogEntryCreateEventHandlers;
+    public GuildAuditLogEntryEventListener(@NonNull Instance<GuildAuditLogEntryCreateEventActionTypeHandler> handlerInstances) {
+        this.handlerInstances = handlerInstances;
     }
 
     @Override
     public void onGuildAuditLogEntryCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
 
         /*
-        Each handler gets its own virtual thread to handle the event
-        or else, the events will be processed sequentially in a single virtual thread.
+        Each handler instance gets its own virtual thread to handle the event's ActionType
+        or else, they will be processed sequentially in a single virtual thread.
         This will be particularly slower if two or more inherited classes have overrides
         for handling the same ActionType.
          */
-        guildAuditLogEntryCreateEventHandlers.forEach(handler -> Thread.ofVirtual()
+        handlerInstances.forEach(handler -> Thread.ofVirtual()
                 .name("guild-audit-log-entry-create-event-listener-vthread-", 0)
                 .start(() -> handler.handleActionType(event))
         );

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
@@ -39,7 +39,11 @@ public final class GuildAuditLogEntryEventListener extends ListenerAdapter {
 
     @Override
     public void onGuildAuditLogEntryCreate(@NonNull GuildAuditLogEntryCreateEvent event) {
-        guildAuditLogEntryCreateEventHandlers.forEach(handler -> handler.handleEvent(event));
+
+        Thread.ofVirtual()
+                .name("guild-audit-log-entry-create-event-listener-vthread-", 0)
+                .start(() -> guildAuditLogEntryCreateEventHandlers.forEach(handler -> handler.handleEvent(event))
+                );
     }
 
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/AuditLogSetupCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/AuditLogSetupCommandListener.java
@@ -26,14 +26,19 @@ public final class AuditLogSetupCommandListener extends ListenerAdapter {
             return;
         }
 
-        switch (event.getSubcommandName()) {
-            case "set" -> handler.setAuditLogging(event);
-            case "view" -> handler.viewAuditLoggingChannel(event);
-            case "remove" -> handler.unsetAuditLogging(event);
-            default -> {
-                // do nothing
-            }
-        }
+        Thread.ofVirtual()
+                .name("audit-log-setup-command-listener-vthread-", 0)
+                .start(() -> {
+                    switch (event.getSubcommandName()) {
+                        case "set" -> handler.setAuditLogging(event);
+                        case "view" -> handler.viewAuditLoggingChannel(event);
+                        case "remove" -> handler.unsetAuditLogging(event);
+                        default -> {
+                            // do nothing
+                        }
+                    }
+                });
+
     }
 
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/BotSetupInstructionCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/BotSetupInstructionCommandListener.java
@@ -21,7 +21,9 @@ public final class BotSetupInstructionCommandListener extends ListenerAdapter {
     public void onSlashCommandInteraction(@NonNull SlashCommandInteractionEvent event) {
 
         if (event.getName().equals("setup")) {
-            handler.sendInstructions(event);
+            Thread.ofVirtual()
+                    .name("bot-setup-instruction-command-listener-vthread-", 0)
+                    .start(() -> handler.sendInstructions(event));
         }
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/DebugCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/DebugCommandListener.java
@@ -34,7 +34,10 @@ public final class DebugCommandListener extends ListenerAdapter {
             return;
         }
 
-        handler.sendDebugInfo(event, guild, member);
+        Thread.ofVirtual()
+                .name("debug-command-listener-vthread-", 0)
+                .start(() -> handler.sendDebugInfo(event, guild, member));
+
 
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/MessageLogSetupCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/MessageLogSetupCommandListener.java
@@ -26,13 +26,18 @@ public final class MessageLogSetupCommandListener extends ListenerAdapter {
             return;
         }
 
-        switch (event.getSubcommandName()) {
-            case "set" -> handler.setMessageLogging(event);
-            case "view" -> handler.viewMessageLoggingChannel(event);
-            case "remove" -> handler.unsetMessageLogging(event);
-            default -> {
-                // skip
-            }
-        }
+        Thread.ofVirtual().name("message-log-setup-command-listener-vthread-", 0)
+                .start(() -> {
+                    switch (event.getSubcommandName()) {
+                        case "set" -> handler.setMessageLogging(event);
+                        case "view" -> handler.viewMessageLoggingChannel(event);
+                        case "remove" -> handler.unsetMessageLogging(event);
+                        default -> {
+                            // skip
+                        }
+                    }
+                });
+
+
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/ServerStatCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/ServerStatCommandListener.java
@@ -33,6 +33,9 @@ public final class ServerStatCommandListener extends ListenerAdapter {
             return;
         }
 
-        handler.sendServerStats(event, guild);
+        Thread.ofVirtual()
+                .name("server-stat-command-listener-vthread-", 0)
+                .start(() -> handler.sendServerStats(event, guild));
+
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildBoostEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildBoostEventListener.java
@@ -21,16 +21,22 @@ public final class GuildBoostEventListener extends ListenerAdapter {
 
     @Override
     public void onGuildUpdateBoostTier(@NonNull GuildUpdateBoostTierEvent event) {
-        handler.handleUpdateBoostTier(event);
+        Thread.ofVirtual()
+                .name("guild-update-boost-tier-event-listener-vthread-", 0)
+                .start(() -> handler.handleUpdateBoostTier(event));
     }
 
     @Override
     public void onGuildUpdateBoostCount(@NonNull GuildUpdateBoostCountEvent event) {
-        handler.handleUpdateBoostCount(event);
+        Thread.ofVirtual()
+                .name("guild-update-boost-count-event-listener-vthread-", 0)
+                .start(() -> handler.handleUpdateBoostCount(event));
     }
 
     @Override
     public void onGuildMemberUpdateBoostTime(@NonNull GuildMemberUpdateBoostTimeEvent event) {
-        handler.handleMemberUpdateBoostTime(event);
+        Thread.ofVirtual()
+                .name("guild-member-update-boost-time-event-listener-vthread-", 0)
+                .start(() -> handler.handleMemberUpdateBoostTime(event));
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildMemberEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildMemberEventListener.java
@@ -23,12 +23,16 @@ public final class GuildMemberEventListener extends ListenerAdapter {
 
     @Override
     public void onGuildMemberJoin(@NonNull GuildMemberJoinEvent event) {
-        handler.handleGuildMemberJoin(event);
+        Thread.ofVirtual()
+                .name("guild-member-join-event-listener-vthread-", 0)
+                .start(() -> handler.handleGuildMemberJoin(event));
     }
 
     @Override
     public void onGuildMemberRemove(@NonNull GuildMemberRemoveEvent event) {
-        handler.handleGuildMemberRemove(event);
+        Thread.ofVirtual()
+                .name("guild-member-remove-event-listener-vthread-", 0)
+                .start(() -> handler.handleGuildMemberRemove(event));
     }
 
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildPollEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildPollEventListener.java
@@ -24,6 +24,8 @@ public final class GuildPollEventListener extends ListenerAdapter {
         if (!event.isFromGuild())
             return;
 
-        handler.handlePollCreationEvent(event);
+        Thread.ofVirtual()
+                .name("guild-poll-creation-event-listener-vthread-", 0)
+                .start(() -> handler.handlePollCreationEvent(event));
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildSecurityIncidentEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildSecurityIncidentEventListener.java
@@ -20,12 +20,18 @@ public final class GuildSecurityIncidentEventListener extends ListenerAdapter {
 
     @Override
     public void onGuildUpdateSecurityIncidentDetections(@NonNull GuildUpdateSecurityIncidentDetectionsEvent event) {
-        handler.handleGuildUpdateSecurityIncidentDetections(event);
+        Thread.ofVirtual()
+                .name("guild-update-security-incident-detection-event-listener-vthread-", 0)
+                .start(() -> handler.handleGuildUpdateSecurityIncidentDetections(event));
+
     }
 
     @Override
     public void onGuildUpdateSecurityIncidentActions(@NonNull GuildUpdateSecurityIncidentActionsEvent event) {
-        handler.handleGuildUpdateSecurityIncidentActions(event);
+        Thread.ofVirtual()
+                .name("guild-update-security-incident-action-event-listener-vthread-", 0)
+                .start(() -> handler.handleGuildUpdateSecurityIncidentActions(event));
+
     }
 
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildVoiceEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildVoiceEventListener.java
@@ -21,6 +21,9 @@ public final class GuildVoiceEventListener extends ListenerAdapter {
 
     @Override
     public void onGuildVoiceUpdate(@NonNull GuildVoiceUpdateEvent event) {
-        handler.handleVoiceUpdateEvent(event);
+        Thread.ofVirtual()
+                .name("guild-voice-update-event-listener-vthread-", 0)
+                .start(() -> handler.handleVoiceUpdateEvent(event));
+
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/message/GuildMessageEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/message/GuildMessageEventListener.java
@@ -31,8 +31,9 @@ public final class GuildMessageEventListener extends ListenerAdapter {
             return;
         }
 
-        handler.handleMessageReceivedEvent(event);
-
+        Thread.ofVirtual()
+                .name("message-received-event-listener-vthread-", 0)
+                .start(() -> handler.handleMessageReceivedEvent(event));
     }
 
     @Override
@@ -42,12 +43,15 @@ public final class GuildMessageEventListener extends ListenerAdapter {
             return;
         }
 
-        handler.handleMessageUpdateEvent(event);
-
+        Thread.ofVirtual()
+                .name("message-update-event-listener-vthread-", 0)
+                .start(() -> handler.handleMessageUpdateEvent(event));
     }
 
     @Override
     public void onMessageDelete(@NonNull MessageDeleteEvent event) {
-        handler.handleMessageDeleteEvent(event);
+        Thread.ofVirtual()
+                .name("message-delete-event-listener-vthread-", 0)
+                .start(() -> handler.handleMessageDeleteEvent(event));
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/misc/SelfKickListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/misc/SelfKickListener.java
@@ -30,7 +30,13 @@ public final class SelfKickListener extends ListenerAdapter {
     @Override
     public void onGuildLeave(@NonNull GuildLeaveEvent event) {
         Guild leftGuild = event.getGuild();
-        auditLogRegistrationClient.deleteRegisteredGuild(leftGuild.getId());
-        messageLogRegistrationClient.deleteRegisteredGuild(leftGuild.getId());
+
+        Thread.ofVirtual()
+                .name("self-guild-leave-event-listener-vthread-", 0)
+                .start(() -> {
+                    auditLogRegistrationClient.deleteRegisteredGuild(leftGuild.getId());
+                    messageLogRegistrationClient.deleteRegisteredGuild(leftGuild.getId());
+                });
+
     }
 }


### PR DESCRIPTION
- Update PaperTrail SDK to 3.0.0 (Retrofit Update)
- Add quarkus-jackson and provide an ObjectMapper bean to the SDK clients
- Re-introduce Virtual Threads
- Rename `GuildAuditLogEntryCreateEventHandler` to `GuildAuditLogEntryCreateEventActionTypeHandler`
- Also rename `handleEvent` method to `handleActionType` in the above class since routing is based on `ActionType`
- Rename `*EventHandler` classes extending the above class to `*ActionTypeHandler`.