### PR TITLE
Native build support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+#Mandatory
+TOKEN=<discord-token>
+API_URL=<papertrail-api-url>
+#Optional
+TOTAL_SHARDS=<defaults-to-1>
+MIN_SHARD_ID=<defaults-to-0>
+MAX_SHARD_ID=<defaults-to-0>
+TWILIGHT_HTTP_PROXY_URL=<defaults-to-blank>
+PORT=<defaults-to-8080>
+LOG_LEVEL=<defaults-to-info>

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -1,0 +1,30 @@
+# ---------- Stage 1: Native Build ----------
+FROM ghcr.io/graalvm/native-image-community:25 AS build
+WORKDIR /native-build
+
+# Copy Maven wrapper
+COPY pom.xml .
+COPY mvnw .
+COPY .mvn .mvn
+
+# Set execution permission for the Maven wrapper
+RUN chmod +x ./mvnw
+RUN ./mvnw -B -e -DskipTests dependency:go-offline
+
+# Copy the source files after dependencies are cached
+COPY src ./src
+
+# Build native binary
+# quarkus defaults to prod
+RUN ./mvnw -B -e clean package -DskipTests -Dnative
+
+# ---------- Stage 2: Minimal Runtime ----------
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
+RUN useradd -r -m papertrailbot
+WORKDIR /app
+
+# Copy the compiled binary
+COPY --from=build /native-build/target/*-runner /app/bot
+
+USER papertrailbot
+ENTRYPOINT ["./bot"]

--- a/README.md
+++ b/README.md
@@ -374,8 +374,10 @@ To build without Docker:
 The built application will be found in the `target` folder of the project.
 
 Please note that native builds are experimental and I will try my best to improve support for it in upcoming versions.
-If you run across errors during native building or running phase of the bot, please create an Issue in GitHub along with
-the build or runtime logs.
+
+You may come across errors which require you to initialize classes during build time
+or missing reflection config during runtime.
+If you run across such errors, create an Issue in GitHub along with the build or runtime logs.
 
 > [!IMPORTANT]
 > As of now, I have no plans to provide pre-built Docker images for native build of the bot.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ API_URL="http://localhost:8080"
 
 #### Option A : Local Deployment
 
-<ins>Using Pre-Built Images</ins>
+##### Using Pre-Built Docker Images
 
 The [GitHub Container Registry](https://github.com/eggy03/PaperTrailBot/pkgs/container/papertrail-bot)
 has pre-built docker images for the bot which you can use.
@@ -127,14 +127,16 @@ you're executing the following commands from:
 docker run -d --name papertrail-bot --env-file .env ghcr.io/eggy03/papertrail-bot:latest
 ```
 
-<ins>Building From Source</ins>
-
-Alternatively, you can use the provided Dockerfile to build from source:
+##### Building From Source
 
 ```bash
 git clone https://github.com/eggy03/PaperTrailBot.git
 cd PaperTrailBot
 ```
+
+###### With Docker
+
+You can use the provided Dockerfile to build from source:
 
 ```bash
 docker build -t papertrail-bot .
@@ -146,6 +148,12 @@ docker run -d --name papertrail-bot --env-file .env papertrail-bot
 > While the above sub-options use `--env-file .env` for examples, you can also pass environment variables directly
 > via `docker -e KEY:"VALUE"`
 
+###### Without Docker
+
+```bash
+./mvnw clean package
+java -jar target/quarkus-app/quarkus-run.jar
+```
 #### Option B: Cloud Deployment
 
 Many cloud platforms support Docker-based deployments directly from a repository.

--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ docker run -d --name papertrail-bot --env-file .env papertrail-bot
 
 To build without Docker:
 
+You will need to have GraalVM or Mandrel (25+) installed in your host machine to make a native build from source
+
 ```bash
 ./mvnw clean package -Dnative
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 * [Overview](#overview)
 * [Repositories](#repositories)
+* [Using The Bot](#using-the-bot)
 * [Self-Host (Auto Configuration)](#self-host-auto-configuration)
 * [Self-Host (Manual Configuration)](#self-host-manual-configuration)
 * [Sharding (Advanced Configuration)](#sharding-advanced-configuration)
@@ -28,10 +29,6 @@ With support for detecting more than 72 events, it can log changes made to: Auto
 Invites, Members, Roles, Channels, Threads, Stages, Events, Polls, Messages, Boosts, Emojis, Stickers, Soundboard,
 Integrations, Webhooks, Moderation Action, Unusual DMs, Raids and Unknown events.
 
-> Get it from here: https://discord.com/discovery/applications/1381658412550590475
-
-Run the `/setup` slash command to see instructions on how to configure the bot for your server.
-
 # Repositories
 
 | Repository                                                               | Description                                                                                          |
@@ -46,17 +43,40 @@ Run the `/setup` slash command to see instructions on how to configure the bot f
 > but large new features will likely not be added. However, changes will be made to keep the bot and its services
 > up to date with the latest Discord API changes.
 
+# Using The Bot
+
+### By Inviting It
+
+A pre-configured and deployed instance is the easiest way to use this bot. Just invite it to your server and that's all.
+
+Get it from here: https://discord.com/discovery/applications/1381658412550590475
+
+Run the `/setup` slash command to see instructions on how to configure the bot for your server.
+
+You do not need to continue reading further if you do not want to self-host the bot.
+
+### By Self Hosting It
+
+The following sections will tell you most of the things you need to know about self-hosting the bot by yourself:
+
 # Self-Host (Auto Configuration)
 
-Select this option if you want a hassle-free deployment locally or in a VPS
-and do not intend to scale your bot across more than 2000 servers.
+> [!NOTE]
+> Uses docker compose and automatically sets up all the services for you.
+>
+> Only autoconfigures 1 instance of each service.
 
 Follow the deployment guide in:
 [PaperTrail-Deployment Repository](https://github.com/eggy03/PaperTrail-Deployment?tab=readme-ov-file)
 
 # Self-Host (Manual Configuration)
 
-This option gives you full control over the services you want to deploy
+> [!NOTE]
+> Gives you full control of the services you want to deploy.
+>
+> You set up each service manually but have full control over the process.
+>
+> Guides are provided for building and deploying each service locally or in cloud, with or without docker.
 
 ## Step 1: Setting up the API Service
 
@@ -176,7 +196,7 @@ Upon successful deployment of all the required services, including the bot, you 
 # Sharding (Advanced Configuration)
 
 > [!NOTE]
-> This section is required only when your bot has reached over 1000 servers.
+> Sharding is required only when your bot reaches 2500 servers.
 
 Sharding splits your bot connection into multiple independent connections to the Discord gateway.
 Each independent connection is called a shard.
@@ -250,11 +270,14 @@ Each process manages 5 shards, together covering all 10 shards.
 
 > [!IMPORTANT]
 > Shard ID ranges must never overlap between running bot processes/instances.
+>
+> `TOTAL_SHARDS` count must be equal for all instances and must reflect the total shards used across all instances
+> combined.
 
 # Synchronizing Rate Limits (Advanced Configuration)
 
 > [!NOTE]
-> This section is required only if you have multiple bot processes running concurrently, like in Example 3 of Sharding.
+> This section is required only if you have multiple instances of the bot running, like in Example 3 of Sharding.
 
 When you run multiple instances/process, the JDA in each process thinks that it has the sole responsibility
 of handling Discord's API rate limits because the processes aren't aware of each other's existence.
@@ -314,6 +337,12 @@ bot cluster.
 
 # Health Checks and Custom Port Configuration
 
+> [!NOTE]
+> Health Checks and Port are automatically configured in case of
+> [Self Host (Auto Configuration)](#self-host-auto-configuration) mode,
+> but require manual configuration for
+> [Self Host (Manual Configuration)](#self-host-manual-configuration) mode.
+
 ## Health Checks
 
 Since v4, it is possible to get health information by probing any of the following health endpoints:
@@ -372,6 +401,8 @@ To build without Docker:
 ```
 
 The built application will be found in the `target` folder of the project.
+
+If your cloud supports building from Dockerfile, point the source towards `Dockerfile.native` in project's root.
 
 Please note that native builds are experimental and I will try my best to improve support for it in upcoming versions.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [Sharding (Advanced Configuration)](#sharding-advanced-configuration)
 * [Synchronizing Rate Limits (Advanced Configuration)](#synchronizing-rate-limits-advanced-configuration)
 * [Health Checks and Custom Port Configuration](#health-checks-and-custom-port-configuration)
+* [Native Builds](#native-builds)
 * [License](#license)
 * [AI Usage Declaration and Policy](#ai-usage-declaration-and-policy)
 * [Help](#help)
@@ -154,6 +155,7 @@ docker run -d --name papertrail-bot --env-file .env papertrail-bot
 ./mvnw clean package
 java -jar target/quarkus-app/quarkus-run.jar
 ```
+
 #### Option B: Cloud Deployment
 
 Many cloud platforms support Docker-based deployments directly from a repository.
@@ -344,6 +346,40 @@ run the application on a different port, you can manually set the `PORT` environ
 | Variable | Description                                           | Default Value | Optional |
 |----------|-------------------------------------------------------|---------------|----------|
 | `PORT`   | Port Number on which the instance of the bot will run | 8080          | Yes      |
+
+# Native Builds
+
+> [!CAUTION]
+> Native builds are experimental
+
+Since `v4.1.3` it is possible to create native builds of the bot. Native builds are recommended
+when you are hosting the bot in a very resource constrained environment,
+and you need the bot to have faster startup times and low memory consumption.
+
+Native builds have a larger and resource incentive build time compared to standard JVM builds.
+
+To build using Docker:
+
+```bash
+docker build -f Dockerfile.native -t papertrail-bot .
+docker run -d --name papertrail-bot --env-file .env papertrail-bot
+```
+
+To build without Docker:
+
+```bash
+./mvnw clean package -Dnative
+```
+
+The built application will be found in the `target` folder of the project.
+
+Please note that native builds are experimental and I will try my best to improve support for it in upcoming versions.
+If you run across errors during native building or running phase of the bot, please create an Issue in GitHub along with
+the build or runtime logs.
+
+> [!IMPORTANT]
+> As of now, I have no plans to provide pre-built Docker images for native build of the bot.
+> Pre-built images will run exclusively in JVM mode.
 
 # License
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.eggy03</groupId>
     <artifactId>papertrailbot</artifactId>
-    <version>4.1.2</version>
+    <version>4.1.3-SNAPSHOT</version>
     <name>PaperTrail Bot</name>
     <description>A simple bot for logging all server and member actions</description>
     <packaging>quarkus</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
         <!-- Dependency Versions -->
         <jda.version>6.4.1</jda.version>
-        <papertrail.sdk.version>3.0.0</papertrail.sdk.version>
+        <papertrail.sdk.version>3.0.1</papertrail.sdk.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <guava.version>33.5.0-jre</guava.version>
         <jetbrains.annotations.version>26.1.0</jetbrains.annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.eggy03</groupId>
     <artifactId>papertrailbot</artifactId>
-    <version>4.1.3-SNAPSHOT</version>
+    <version>4.1.3</version>
     <name>PaperTrail Bot</name>
     <description>A simple bot for logging all server and member actions</description>
     <packaging>quarkus</packaging>

--- a/src/main/java/io/github/eggy03/papertrail/bot/constant/ProjectInfo.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/constant/ProjectInfo.java
@@ -10,7 +10,7 @@ public final class ProjectInfo {
     public static final String APPNAME = "PaperTrail";
 
     @NonNull
-    public static final String VERSION = "v4.1.2";
+    public static final String VERSION = "v4.1.3-SNAPSHOT";
 
     @NonNull
     public static final String PROJECT_ISSUE_LINK = "https://github.com/eggy03/PaperTrailBot/issues";

--- a/src/main/java/io/github/eggy03/papertrail/bot/constant/ProjectInfo.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/constant/ProjectInfo.java
@@ -10,7 +10,7 @@ public final class ProjectInfo {
     public static final String APPNAME = "PaperTrail";
 
     @NonNull
-    public static final String VERSION = "v4.1.3-SNAPSHOT";
+    public static final String VERSION = "v4.1.3";
 
     @NonNull
     public static final String PROJECT_ISSUE_LINK = "https://github.com/eggy03/PaperTrailBot/issues";

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/misc/ActivityUpdateListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/misc/ActivityUpdateListener.java
@@ -1,6 +1,8 @@
 package io.github.eggy03.papertrail.bot.listeners.misc;
 
 import io.github.eggy03.papertrail.bot.constant.ProjectInfo;
+import io.quarkus.runtime.ImageMode;
+import io.quarkus.runtime.LaunchMode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import lombok.NonNull;
@@ -16,8 +18,7 @@ import net.dv8tion.jda.api.sharding.ShardManager;
 @Slf4j
 public final class ActivityUpdateListener extends ListenerAdapter {
 
-    @NonNull
-    private final ShardManager manager;
+    private final @NonNull ShardManager manager;
 
     @Inject
     public ActivityUpdateListener(@NonNull ShardManager manager) {
@@ -26,23 +27,35 @@ public final class ActivityUpdateListener extends ListenerAdapter {
 
     @Override
     public void onReady(@NonNull ReadyEvent event) { // update on cold start
-        updateActivity();
+        manager.setActivity(Activity.customStatus(
+                "/setup | " + ProjectInfo.VERSION + " | " + getImageMode() + " | " + getLaunchMode())
+        );
     }
 
     @Override
     public void onGuildJoin(@NonNull GuildJoinEvent event) { // update on guild join
         log.debug("Bot Added To [Guild={}, ID={}]", event.getGuild().getName(), event.getGuild().getId());
-        updateActivity();
     }
 
     @Override
     public void onGuildLeave(@NonNull GuildLeaveEvent event) { // update on guild leave
         log.debug("Bot Removed From [Guild={}, ID={}]", event.getGuild().getName(), event.getGuild().getId());
-        updateActivity();
     }
 
-    private void updateActivity() {
-        manager.setActivity(Activity.customStatus("/setup | " + manager.getGuildCache().size() + " Servers | " + ProjectInfo.VERSION));
+    private @NonNull String getLaunchMode() {
+        return switch (LaunchMode.current()) {
+            case DEVELOPMENT -> "Dev";
+            case NORMAL -> "Production";
+            case RUN -> "Production w/ Dev Services";
+            case TEST -> "Test";
+        };
     }
 
+    private @NonNull String getImageMode() {
+        return switch (ImageMode.current()) {
+            case JVM -> "JVM";
+            case NATIVE_BUILD -> "Native Build Phase";
+            case NATIVE_RUN -> "Native";
+        };
+    }
 }

--- a/src/main/resources/META-INF/native-image/io/github/eggy03/papertrailbot/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/io/github/eggy03/papertrailbot/reachability-metadata.json
@@ -34,6 +34,30 @@
       "allDeclaredMethods": true
     },
     {
+      "type": {
+        "proxy": [
+          "io.github.eggy03.papertrail.sdk.service.AuditLogRegistrationService"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "io.github.eggy03.papertrail.sdk.service.MessageLogRegistrationService"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "io.github.eggy03.papertrail.sdk.service.MessageLogContentService"
+        ]
+      }
+    },
+    {
+      "type": "net.dv8tion.jda.api.JDA[]"
+    },
+    {
       "type": "net.dv8tion.jda.api.entities.User[]"
     },
     {
@@ -77,6 +101,21 @@
     },
     {
       "type": "net.dv8tion.jda.api.entities.SoundboardSound[]"
+    },
+    {
+      "type": "net.dv8tion.jda.api.entities.channel.attribute.IGuildChannelContainer"
+    },
+    {
+      "type": "net.dv8tion.jda.api.hooks.EventListener",
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "net.dv8tion.jda.api.hooks.ListenerAdapter",
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredFields": true
     }
   ]
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,10 +26,10 @@ quarkus.analytics.disabled=true
 
 # Banner
 quarkus.banner.path=banner.txt
+
 # Native Build Args
 quarkus.native.additional-build-args=\
     --trace-object-instantiation=java.security.SecureRandom,\
     --initialize-at-run-time=\
-        com.neovisionaries.ws.client\\,\
-        net.dv8tion.jda.internal.audio.CryptoAdapter$AbstractAaedAdapter\\,\
-        net.dv8tion.jda.internal.requests.restaction.MessageCreateActionImpl
+        com.neovisionaries.ws.client.Misc\\,\
+        net.dv8tion.jda.internal.audio.CryptoAdapter$AbstractAaedAdapter

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,4 +32,5 @@ quarkus.native.additional-build-args=\
     --trace-object-instantiation=java.security.SecureRandom,\
     --initialize-at-run-time=\
         com.neovisionaries.ws.client.Misc\\,\
-        net.dv8tion.jda.internal.audio.CryptoAdapter$AbstractAaedAdapter
+        net.dv8tion.jda.internal.audio.CryptoAdapter$AbstractAaedAdapter\\,\
+        net.dv8tion.jda.internal.requests.restaction.MessageCreateActionImpl


### PR DESCRIPTION
## **Description**

This PR adds experimental native build support for the bot.

## **Type of Change**

#### Build
- Experimental Support for Native Builds
- Added `Dockerfile.native` to allow building the native image in docker

#### Refactor
- Activity Listener does not show server count anymore. Instead, it shows whether the bot is running in JVM Mode or Native

#### Documentation
- Readme has been updated to include build instructions for non docker deployments
- Also added a reference to `Dockerfile.native` for native building from source with and without docker

#### Dependency
- Update PaperTrai SDK to 3.0.1

#### Other
- Added `.env.example`

---

## **Tasks for Native Builds**

- [x] New Code Added
    - [x] New Code Tested In Native Build
- [x] Dependencies Updated
    - [x] Dependencies Updates Tested In Native Build
- [x] Reachability Metadata Updated
    - [x] Update Tested In Native Build