### PR TITLE
Develop 4.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.eggy03</groupId>
     <artifactId>papertrailbot</artifactId>
-    <version>4.1.7</version>
+    <version>4.1.8-SNAPSHOT</version>
     <name>PaperTrail Bot</name>
     <description>A simple bot for logging all server and member actions</description>
     <packaging>quarkus</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.eggy03</groupId>
     <artifactId>papertrailbot</artifactId>
-    <version>4.1.8-SNAPSHOT</version>
+    <version>4.1.8</version>
     <name>PaperTrail Bot</name>
     <description>A simple bot for logging all server and member actions</description>
     <packaging>quarkus</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <!-- Quarkus Properties -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.36.2</quarkus.platform.version>
+        <quarkus.platform.version>3.36.3</quarkus.platform.version>
         <skipITs>true</skipITs>
 
         <!-- Dependency Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <!-- Quarkus Properties -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.36.3</quarkus.platform.version>
+        <quarkus.platform.version>3.37.0</quarkus.platform.version>
         <skipITs>true</skipITs>
 
         <!-- Dependency Versions -->

--- a/src/main/java/io/github/eggy03/papertrail/bot/about/ApplicationInfo.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/about/ApplicationInfo.java
@@ -1,4 +1,4 @@
-package io.github.eggy03.papertrail.bot.bean;
+package io.github.eggy03.papertrail.bot.about;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/RoleActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/RoleActionTypeHandler.java
@@ -79,6 +79,7 @@ public final class RoleActionTypeHandler extends GuildAuditLogEntryCreateEventAc
                 case "name" -> eb.addField(MarkdownUtil.underline("Role Name"), "╰┈➤" + newValue, false);
 
                 case "colors", "hoist", "color", "permissions", "mentionable" -> {
+                    // do nothing
                     /* discord for some reason shows the following to be default/null even
                      * when you set them during the creation of the role itself
                      * and delegates them to ROLE_UPDATE event
@@ -157,6 +158,9 @@ public final class RoleActionTypeHandler extends GuildAuditLogEntryCreateEventAc
                     eb.addField(MarkdownUtil.underline("New Gradient Color System"), RoleUtils.formatGradientToHex(newValue), true);
                     eb.addBlankField(true);
                 }
+
+                case "icon_hash" ->
+                        eb.addField(MarkdownUtil.underline("Role Icon Update"), "╰┈➤Role Icon has been updated", false);
 
                 default -> {
                     eb.addField("Unimplemented Change Key", changeKey, false);

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ScheduledEventActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ScheduledEventActionTypeHandler.java
@@ -76,6 +76,10 @@ public final class ScheduledEventActionTypeHandler extends GuildAuditLogEntryCre
                 case "status" ->
                         eb.addField(MarkdownUtil.underline("Event Status"), "╰┈➤" + ScheduledEventUtils.resolveStatusType(newValue), false);
                 case "location" -> eb.addField(MarkdownUtil.underline("Event Location"), "╰┈➤" + newValue, false);
+                case "scheduled_start_time" ->
+                        eb.addField(MarkdownUtil.underline("Event Start Time"), "╰┈➤" + ScheduledEventUtils.convertISOTimeToDiscordTimeStamp(newValue), false);
+                case "scheduled_end_time" ->
+                        eb.addField("Event End Time", "╰┈➤" + ScheduledEventUtils.convertISOTimeToDiscordTimeStamp(newValue), false);
                 case "privacy_level", "image_hash", "channel_id", "recurrence_rule" -> {
                     // skip
                 }
@@ -134,10 +138,22 @@ public final class ScheduledEventActionTypeHandler extends GuildAuditLogEntryCre
                     eb.addBlankField(true);
                 }
                 case "location" -> {
-                    eb.addField(MarkdownUtil.underline("Event Location"), "╰┈➤" + oldValue, true);
-                    eb.addField(MarkdownUtil.underline("Event Location"), "╰┈➤" + newValue, true);
+                    eb.addField(MarkdownUtil.underline("Old Event Location"), "╰┈➤" + oldValue, true);
+                    eb.addField(MarkdownUtil.underline("New Event Location"), "╰┈➤" + newValue, true);
                     eb.addBlankField(true);
                 }
+
+                case "scheduled_start_time" -> {
+                    eb.addField(MarkdownUtil.underline("Old Event Start Time"), "╰┈➤" + ScheduledEventUtils.convertISOTimeToDiscordTimeStamp(oldValue), true);
+                    eb.addField(MarkdownUtil.underline("New Event Start Time"), "╰┈➤" + ScheduledEventUtils.convertISOTimeToDiscordTimeStamp(newValue), true);
+                    eb.addBlankField(true);
+                }
+                case "scheduled_end_time" -> {
+                    eb.addField("Old Event End Time", "╰┈➤" + ScheduledEventUtils.convertISOTimeToDiscordTimeStamp(oldValue), true);
+                    eb.addField("New Event End Time", "╰┈➤" + ScheduledEventUtils.convertISOTimeToDiscordTimeStamp(newValue), true);
+                    eb.addBlankField(true);
+                }
+
                 case "privacy_level" ->
                         eb.addField(MarkdownUtil.underline("Privacy"), "╰┈➤Event privacy has been updated", false);
                 case "image_hash" ->
@@ -188,6 +204,10 @@ public final class ScheduledEventActionTypeHandler extends GuildAuditLogEntryCre
                 case "status" ->
                         eb.addField(MarkdownUtil.underline("Event Status"), "╰┈➤" + ScheduledEventUtils.resolveStatusType(oldValue), false);
                 case "location" -> eb.addField(MarkdownUtil.underline("Event Location"), "╰┈➤" + oldValue, false);
+                case "scheduled_start_time" ->
+                        eb.addField(MarkdownUtil.underline("Event Start Time"), "╰┈➤" + ScheduledEventUtils.convertISOTimeToDiscordTimeStamp(oldValue), false);
+                case "scheduled_end_time" ->
+                        eb.addField("Event End Time", "╰┈➤" + ScheduledEventUtils.convertISOTimeToDiscordTimeStamp(oldValue), false);
                 case "privacy_level", "image_hash", "channel_id", "recurrence_rule" -> {
                     // skip
                 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ThreadActionTypeHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/auditlog/ThreadActionTypeHandler.java
@@ -92,7 +92,7 @@ public final class ThreadActionTypeHandler extends GuildAuditLogEntryCreateEvent
                 case "archived" ->
                         eb.addField(MarkdownUtil.underline("Archived"), "╰┈➤" + BooleanUtils.formatToYesOrNo(newValue), false);
 
-                case "flags" -> {
+                case "flags", "applied_tags" -> {
                     // skip
                 }
                 case "invitable" ->
@@ -163,7 +163,10 @@ public final class ThreadActionTypeHandler extends GuildAuditLogEntryCreateEvent
                     eb.addField(MarkdownUtil.underline("New Archive Status"), "╰┈➤" + BooleanUtils.formatToEnabledOrDisabled(newValue), true);
                     eb.addBlankField(true);
                 }
+
                 case "flags" -> eb.addField(MarkdownUtil.underline("Flags"), "╰┈➤Thread flags were updated", false);
+                case "applied_tags" ->
+                        eb.addField(MarkdownUtil.underline("Applied Tags"), "╰┈➤Applied Tags were updated", false);
 
                 case "invitable" -> {
                     eb.addField(MarkdownUtil.underline("Was Invitable"), "╰┈➤" + BooleanUtils.formatToYesOrNo(oldValue), true);
@@ -224,7 +227,7 @@ public final class ThreadActionTypeHandler extends GuildAuditLogEntryCreateEvent
                 case "archived" ->
                         eb.addField(MarkdownUtil.underline("Archived"), "╰┈➤" + BooleanUtils.formatToYesOrNo(oldValue), false);
 
-                case "flags" -> {
+                case "flags", "applied_tags" -> {
                     // skip
                 }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/command/BotSetupInstructionCommandHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/command/BotSetupInstructionCommandHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.command;
 
-import io.github.eggy03.papertrail.bot.bean.ApplicationInfo;
+import io.github.eggy03.papertrail.bot.about.ApplicationInfo;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import lombok.NonNull;

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/command/DebugCommandHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/command/DebugCommandHandler.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.command;
 
-import io.github.eggy03.papertrail.bot.bean.ApplicationInfo;
+import io.github.eggy03.papertrail.bot.about.ApplicationInfo;
 import io.github.eggy03.papertrail.bot.utils.BooleanUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.client.MessageLogRegistrationClient;

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/command/ServerStatCommandHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/command/ServerStatCommandHandler.java
@@ -1,5 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.command;
 
+import io.github.eggy03.papertrail.bot.utils.DurationUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import lombok.NonNull;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -66,7 +67,7 @@ public final class ServerStatCommandHandler {
 
     @NonNull
     private String getGuildCreationDate(@NonNull Guild guild) {
-        return "<t:" + guild.getTimeCreated().toEpochSecond() + ":f>";
+        return DurationUtils.isoToLocalTimeCounter(guild.getTimeCreated());
     }
 
     @NonNull

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/guild/GuildMemberEventHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/guild/GuildMemberEventHandler.java
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import org.apache.commons.lang3.StringUtils;
 
 import java.awt.Color;
@@ -110,13 +111,13 @@ public final class GuildMemberEventHandler {
             return "Member not cached";
 
         if (member.hasTimeJoined())
-            return "<t:" + member.getTimeJoined().toEpochSecond() + ":f>";
+            return TimeFormat.DATE_TIME_LONG.format(member.getTimeJoined());
 
         return "Unavailable";
     }
 
     @NonNull
     private String getMemberLeaveDate() {
-        return "<t:" + Instant.now().getEpochSecond() + ":f>";
+        return TimeFormat.DATE_TIME_LONG.format(Instant.now());
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/guild/GuildPollEventHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/guild/GuildPollEventHandler.java
@@ -12,6 +12,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.messages.MessagePoll;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import org.apache.commons.lang3.StringUtils;
 
 import java.awt.Color;
@@ -91,7 +92,7 @@ public final class GuildPollEventHandler {
     @NonNull
     private String getPollExpiryTime(@NonNull MessagePoll messagePoll) {
         return messagePoll.getTimeExpiresAt() != null ?
-                "<t:" + messagePoll.getTimeExpiresAt().toEpochSecond() + ":f>" :
+                TimeFormat.DATE_TIME_LONG.format(messagePoll.getTimeExpiresAt()) :
                 "Never Expires";
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/handlers/guild/GuildSecurityIncidentEventHandler.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/handlers/guild/GuildSecurityIncidentEventHandler.java
@@ -1,5 +1,6 @@
 package io.github.eggy03.papertrail.bot.handlers.guild;
 
+import io.github.eggy03.papertrail.bot.utils.DurationUtils;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.entity.AuditLogRegistrationEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -15,7 +16,6 @@ import net.dv8tion.jda.api.events.guild.update.GuildUpdateSecurityIncidentAction
 import net.dv8tion.jda.api.events.guild.update.GuildUpdateSecurityIncidentDetectionsEvent;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
 import org.apache.commons.lang3.StringUtils;
-import org.jspecify.annotations.Nullable;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -51,11 +51,6 @@ public final class GuildSecurityIncidentEventHandler {
         }
     }
 
-    private @NonNull String formatOffsetDateTime(@Nullable OffsetDateTime offsetDateTime) {
-        if (offsetDateTime == null) return "N/A";
-        return "<t:" + offsetDateTime.toEpochSecond() + ":f>";
-    }
-
     public void handleGuildUpdateSecurityIncidentDetections(@NonNull GuildUpdateSecurityIncidentDetectionsEvent event) {
         String channelIdToSendTo = getRegisteredChannelId(event.getGuild().getId());
         if (channelIdToSendTo.isBlank()) return;
@@ -74,7 +69,7 @@ public final class GuildSecurityIncidentEventHandler {
             eb.setTitle("Audit Log Entry | Security Incident Resolved");
             eb.setDescription(MarkdownUtil.quoteBlock("Incident Type: DM Spam\nStatus: Resolved"));
             eb.setColor(Color.GREEN);
-            eb.addField(MarkdownUtil.underline("DM Spam Started At"), formatOffsetDateTime(oldDMSpamDetectedAt), false);
+            eb.addField(MarkdownUtil.underline("DM Spam Started At"), DurationUtils.isoToLocalTimeCounter(oldDMSpamDetectedAt), false);
             eb.setFooter(event.getGuild().getName());
             eb.setTimestamp(Instant.now());
 
@@ -86,7 +81,7 @@ public final class GuildSecurityIncidentEventHandler {
             eb.setTitle("Audit Log Entry | Security Incident Detected");
             eb.setDescription(MarkdownUtil.quoteBlock("Incident Type: DM Spam\nStatus: Detected"));
             eb.setColor(Color.ORANGE);
-            eb.addField(MarkdownUtil.underline("DM Spam Detected At"), formatOffsetDateTime(newDMSpamDetectedAt), false);
+            eb.addField(MarkdownUtil.underline("DM Spam Detected At"), DurationUtils.isoToLocalTimeCounter(newDMSpamDetectedAt), false);
             eb.setFooter(event.getGuild().getName());
             eb.setTimestamp(Instant.now());
 
@@ -98,7 +93,7 @@ public final class GuildSecurityIncidentEventHandler {
             eb.setTitle("Audit Log Entry | Security Incident Resolved");
             eb.setDescription(MarkdownUtil.quoteBlock("Incident Type: RAID\nStatus: Resolved"));
             eb.setColor(Color.GREEN);
-            eb.addField(MarkdownUtil.underline("Raid Was Detected At"), formatOffsetDateTime(oldRaidDetectedAt), false);
+            eb.addField(MarkdownUtil.underline("Raid Was Detected At"), DurationUtils.isoToLocalTimeCounter(oldRaidDetectedAt), false);
             eb.setFooter(event.getGuild().getName());
             eb.setTimestamp(Instant.now());
 
@@ -110,7 +105,7 @@ public final class GuildSecurityIncidentEventHandler {
             eb.setTitle("Audit Log Entry | Security Incident Detected");
             eb.setDescription(MarkdownUtil.quoteBlock("Incident Type: RAID\nStatus: Detected"));
             eb.setColor(Color.ORANGE);
-            eb.addField(MarkdownUtil.underline("Raid Detected At"), formatOffsetDateTime(newRaidDetectedAt), false);
+            eb.addField(MarkdownUtil.underline("Raid Detected At"), DurationUtils.isoToLocalTimeCounter(newRaidDetectedAt), false);
             eb.setFooter(event.getGuild().getName());
             eb.setTimestamp(Instant.now());
 
@@ -136,7 +131,7 @@ public final class GuildSecurityIncidentEventHandler {
             eb.setTitle("Audit Log Entry | Security Action Disabled");
             eb.setDescription(MarkdownUtil.quoteBlock("Action Type: DM Pause\nStatus: Disabled"));
             eb.setColor(Color.GREEN);
-            eb.addField(MarkdownUtil.underline("DMs Were Paused Until"), formatOffsetDateTime(oldDMDisabledUntil), false);
+            eb.addField(MarkdownUtil.underline("DMs Were Paused Until"), DurationUtils.isoToLocalTimeCounter(oldDMDisabledUntil), false);
             eb.setFooter(event.getGuild().getName());
             eb.setTimestamp(Instant.now());
 
@@ -148,7 +143,7 @@ public final class GuildSecurityIncidentEventHandler {
             eb.setTitle("Audit Log Entry | Security Action Enabled");
             eb.setDescription(MarkdownUtil.quoteBlock("Action Type: DM Pause\nStatus: Enabled"));
             eb.setColor(Color.ORANGE);
-            eb.addField(MarkdownUtil.underline("DMs Paused Until"), formatOffsetDateTime(newDMDisabledUntil), false);
+            eb.addField(MarkdownUtil.underline("DMs Paused Until"), DurationUtils.isoToLocalTimeCounter(newDMDisabledUntil), false);
             eb.setFooter(event.getGuild().getName());
             eb.setTimestamp(Instant.now());
 
@@ -160,7 +155,7 @@ public final class GuildSecurityIncidentEventHandler {
             eb.setTitle("Audit Log Entry | Security Action Disabled");
             eb.setDescription(MarkdownUtil.quoteBlock("Action Type: Invite Pause\nStatus: Disabled"));
             eb.setColor(Color.GREEN);
-            eb.addField(MarkdownUtil.underline("Invites Were Paused Until"), formatOffsetDateTime(oldInvitesPausedUntil), false);
+            eb.addField(MarkdownUtil.underline("Invites Were Paused Until"), DurationUtils.isoToLocalTimeCounter(oldInvitesPausedUntil), false);
             eb.setFooter(event.getGuild().getName());
             eb.setTimestamp(Instant.now());
 
@@ -172,7 +167,7 @@ public final class GuildSecurityIncidentEventHandler {
             eb.setTitle("Audit Log Entry | Security Action Enabled");
             eb.setDescription(MarkdownUtil.quoteBlock("Action Type: Invite Pause\nStatus: Enabled"));
             eb.setColor(Color.ORANGE);
-            eb.addField(MarkdownUtil.underline("Invites Paused Until"), formatOffsetDateTime(newInvitesPausedUntil), false);
+            eb.addField(MarkdownUtil.underline("Invites Paused Until"), DurationUtils.isoToLocalTimeCounter(newInvitesPausedUntil), false);
             eb.setFooter(event.getGuild().getName());
             eb.setTimestamp(Instant.now());
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/auditlog/GuildAuditLogEntryEventListener.java
@@ -1,5 +1,6 @@
 package io.github.eggy03.papertrail.bot.listeners.auditlog;
 
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -7,6 +8,8 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.util.concurrent.ThreadFactory;
 
 /**
  * Listener responsible for receiving {@link GuildAuditLogEntryCreateEvent}
@@ -30,10 +33,15 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 public final class GuildAuditLogEntryEventListener extends ListenerAdapter {
 
     private final @NonNull Instance<GuildAuditLogEntryCreateEventActionTypeHandler> handlerInstances;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public GuildAuditLogEntryEventListener(@NonNull Instance<GuildAuditLogEntryCreateEventActionTypeHandler> handlerInstances) {
+    public GuildAuditLogEntryEventListener(@NonNull Instance<GuildAuditLogEntryCreateEventActionTypeHandler> handlerInstances,
+                                           @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory
+    ) {
         this.handlerInstances = handlerInstances;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -49,9 +57,10 @@ public final class GuildAuditLogEntryEventListener extends ListenerAdapter {
         This will be particularly slower if two or more inherited classes have overrides
         for handling the same ActionType.
          */
-        handlerInstances.forEach(handler -> Thread.ofVirtual()
-                .name("guild-audit-log-entry-create-event-listener-vthread-", 0)
-                .start(() -> handler.handleActionType(event))
+        handlerInstances.forEach(handler ->
+                virtualThreadFactory
+                        .newThread(() -> handler.handleActionType(event))
+                        .start()
         );
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/AuditLogSetupCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/AuditLogSetupCommandListener.java
@@ -1,22 +1,26 @@
 package io.github.eggy03.papertrail.bot.listeners.command;
 
 import io.github.eggy03.papertrail.bot.handlers.command.AuditLogSetupCommandHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 @Singleton
-@Slf4j
 public final class AuditLogSetupCommandListener extends ListenerAdapter {
 
     private final @NonNull AuditLogSetupCommandHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public AuditLogSetupCommandListener(@NonNull AuditLogSetupCommandHandler handler) {
+    public AuditLogSetupCommandListener(@NonNull AuditLogSetupCommandHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -26,19 +30,16 @@ public final class AuditLogSetupCommandListener extends ListenerAdapter {
             return;
         }
 
-        Thread.ofVirtual()
-                .name("audit-log-setup-command-listener-vthread-", 0)
-                .start(() -> {
-                    switch (event.getSubcommandName()) {
-                        case "set" -> handler.setAuditLogging(event);
-                        case "view" -> handler.viewAuditLoggingChannel(event);
-                        case "remove" -> handler.unsetAuditLogging(event);
-                        default -> {
-                            // do nothing
-                        }
-                    }
-                });
-
+        virtualThreadFactory.newThread(() -> {
+            switch (event.getSubcommandName()) {
+                case "set" -> handler.setAuditLogging(event);
+                case "view" -> handler.viewAuditLoggingChannel(event);
+                case "remove" -> handler.unsetAuditLogging(event);
+                default -> {
+                    // do nothing
+                }
+            }
+        }).start();
     }
 
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/BotSetupInstructionCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/BotSetupInstructionCommandListener.java
@@ -1,29 +1,37 @@
 package io.github.eggy03.papertrail.bot.listeners.command;
 
 import io.github.eggy03.papertrail.bot.handlers.command.BotSetupInstructionCommandHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 @Singleton
 public final class BotSetupInstructionCommandListener extends ListenerAdapter {
 
     private final @NonNull BotSetupInstructionCommandHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public BotSetupInstructionCommandListener(@NonNull BotSetupInstructionCommandHandler handler) {
+    public BotSetupInstructionCommandListener(@NonNull BotSetupInstructionCommandHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
     public void onSlashCommandInteraction(@NonNull SlashCommandInteractionEvent event) {
 
         if (event.getName().equals("setup")) {
-            Thread.ofVirtual()
-                    .name("bot-setup-instruction-command-listener-vthread-", 0)
-                    .start(() -> handler.sendInstructions(event));
+
+            virtualThreadFactory
+                    .newThread(() -> handler.sendInstructions(event))
+                    .start();
+
         }
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/DebugCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/DebugCommandListener.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.listeners.command;
 
 import io.github.eggy03.papertrail.bot.handlers.command.DebugCommandHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -10,15 +11,20 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 @Slf4j
 @Singleton
 public final class DebugCommandListener extends ListenerAdapter {
 
     private final @NonNull DebugCommandHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public DebugCommandListener(@NonNull DebugCommandHandler handler) {
+    public DebugCommandListener(@NonNull DebugCommandHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -34,10 +40,8 @@ public final class DebugCommandListener extends ListenerAdapter {
             return;
         }
 
-        Thread.ofVirtual()
-                .name("debug-command-listener-vthread-", 0)
-                .start(() -> handler.sendDebugInfo(event, guild, member));
-
-
+        virtualThreadFactory
+                .newThread(() -> handler.sendDebugInfo(event, guild, member))
+                .start();
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/MessageLogSetupCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/MessageLogSetupCommandListener.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.listeners.command;
 
 import io.github.eggy03.papertrail.bot.handlers.command.MessageLogSetupCommandHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -8,15 +9,20 @@ import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 @Slf4j
 @Singleton
 public final class MessageLogSetupCommandListener extends ListenerAdapter {
 
     private final @NonNull MessageLogSetupCommandHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public MessageLogSetupCommandListener(@NonNull MessageLogSetupCommandHandler handler) {
+    public MessageLogSetupCommandListener(@NonNull MessageLogSetupCommandHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -26,18 +32,15 @@ public final class MessageLogSetupCommandListener extends ListenerAdapter {
             return;
         }
 
-        Thread.ofVirtual().name("message-log-setup-command-listener-vthread-", 0)
-                .start(() -> {
-                    switch (event.getSubcommandName()) {
-                        case "set" -> handler.setMessageLogging(event);
-                        case "view" -> handler.viewMessageLoggingChannel(event);
-                        case "remove" -> handler.unsetMessageLogging(event);
-                        default -> {
-                            // skip
-                        }
-                    }
-                });
-
-
+        virtualThreadFactory.newThread(() -> {
+            switch (event.getSubcommandName()) {
+                case "set" -> handler.setMessageLogging(event);
+                case "view" -> handler.viewMessageLoggingChannel(event);
+                case "remove" -> handler.unsetMessageLogging(event);
+                default -> {
+                    // skip
+                }
+            }
+        }).start();
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/ServerStatCommandListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/command/ServerStatCommandListener.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.listeners.command;
 
 import io.github.eggy03.papertrail.bot.handlers.command.ServerStatCommandHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -9,15 +10,20 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 @Singleton
 @Slf4j
 public final class ServerStatCommandListener extends ListenerAdapter {
 
     private final @NonNull ServerStatCommandHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public ServerStatCommandListener(@NonNull ServerStatCommandHandler handler) {
+    public ServerStatCommandListener(@NonNull ServerStatCommandHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -33,9 +39,9 @@ public final class ServerStatCommandListener extends ListenerAdapter {
             return;
         }
 
-        Thread.ofVirtual()
-                .name("server-stat-command-listener-vthread-", 0)
-                .start(() -> handler.sendServerStats(event, guild));
+        virtualThreadFactory
+                .newThread(() -> handler.sendServerStats(event, guild))
+                .start();
 
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildBoostEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildBoostEventListener.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.listeners.guild;
 
 import io.github.eggy03.papertrail.bot.handlers.guild.GuildBoostEventHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -10,15 +11,20 @@ import net.dv8tion.jda.api.events.guild.update.GuildUpdateBoostCountEvent;
 import net.dv8tion.jda.api.events.guild.update.GuildUpdateBoostTierEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 @Singleton
 @Slf4j
 public final class GuildBoostEventListener extends ListenerAdapter {
 
     private final @NonNull GuildBoostEventHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public GuildBoostEventListener(@NonNull GuildBoostEventHandler handler) {
+    public GuildBoostEventListener(@NonNull GuildBoostEventHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -28,9 +34,9 @@ public final class GuildBoostEventListener extends ListenerAdapter {
                 event.getGuild().getName(), event.getGuild().getId()
         );
 
-        Thread.ofVirtual()
-                .name("guild-update-boost-tier-event-listener-vthread-", 0)
-                .start(() -> handler.handleUpdateBoostTier(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleUpdateBoostTier(event))
+                .start();
     }
 
     @Override
@@ -40,9 +46,9 @@ public final class GuildBoostEventListener extends ListenerAdapter {
                 event.getGuild().getName(), event.getGuild().getId()
         );
 
-        Thread.ofVirtual()
-                .name("guild-update-boost-count-event-listener-vthread-", 0)
-                .start(() -> handler.handleUpdateBoostCount(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleUpdateBoostCount(event))
+                .start();
     }
 
     @Override
@@ -52,8 +58,8 @@ public final class GuildBoostEventListener extends ListenerAdapter {
                 event.getGuild().getName(), event.getGuild().getId()
         );
 
-        Thread.ofVirtual()
-                .name("guild-member-update-boost-time-event-listener-vthread-", 0)
-                .start(() -> handler.handleMemberUpdateBoostTime(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleMemberUpdateBoostTime(event))
+                .start();
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildMemberEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildMemberEventListener.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.listeners.guild;
 
 import io.github.eggy03.papertrail.bot.handlers.guild.GuildMemberEventHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -9,6 +10,8 @@ import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 // this event is not properly logged in the audit logs, hence the usage of JDA's listener is preferred
 // this event is logged in the same channel where the audit log events are logged
 @Singleton
@@ -16,10 +19,13 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 public final class GuildMemberEventListener extends ListenerAdapter {
 
     private final @NonNull GuildMemberEventHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public GuildMemberEventListener(@NonNull GuildMemberEventHandler handler) {
+    public GuildMemberEventListener(@NonNull GuildMemberEventHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
 
@@ -30,9 +36,9 @@ public final class GuildMemberEventListener extends ListenerAdapter {
                 event.getGuild().getName(), event.getGuild().getId()
         );
 
-        Thread.ofVirtual()
-                .name("guild-member-join-event-listener-vthread-", 0)
-                .start(() -> handler.handleGuildMemberJoin(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleGuildMemberJoin(event))
+                .start();
     }
 
     @Override
@@ -42,9 +48,9 @@ public final class GuildMemberEventListener extends ListenerAdapter {
                 event.getGuild().getName(), event.getGuild().getId()
         );
 
-        Thread.ofVirtual()
-                .name("guild-member-remove-event-listener-vthread-", 0)
-                .start(() -> handler.handleGuildMemberRemove(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleGuildMemberRemove(event))
+                .start();
     }
 
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildPollEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildPollEventListener.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.listeners.guild;
 
 import io.github.eggy03.papertrail.bot.handlers.guild.GuildPollEventHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -8,16 +9,21 @@ import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 // guild poll events are mapped to audit log table
 @Singleton
 @Slf4j
 public final class GuildPollEventListener extends ListenerAdapter {
 
     private final @NonNull GuildPollEventHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public GuildPollEventListener(@NonNull GuildPollEventHandler handler) {
+    public GuildPollEventListener(@NonNull GuildPollEventHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -31,8 +37,8 @@ public final class GuildPollEventListener extends ListenerAdapter {
                 event.getGuild().getName(), event.getGuild().getId()
         );
 
-        Thread.ofVirtual()
-                .name("guild-poll-creation-event-listener-vthread-", 0)
-                .start(() -> handler.handlePollCreationEvent(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handlePollCreationEvent(event))
+                .start();
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildSecurityIncidentEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildSecurityIncidentEventListener.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.listeners.guild;
 
 import io.github.eggy03.papertrail.bot.handlers.guild.GuildSecurityIncidentEventHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -9,15 +10,20 @@ import net.dv8tion.jda.api.events.guild.update.GuildUpdateSecurityIncidentAction
 import net.dv8tion.jda.api.events.guild.update.GuildUpdateSecurityIncidentDetectionsEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 @Singleton
 @Slf4j
 public final class GuildSecurityIncidentEventListener extends ListenerAdapter {
 
     private final @NonNull GuildSecurityIncidentEventHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public GuildSecurityIncidentEventListener(@NonNull GuildSecurityIncidentEventHandler handler) {
+    public GuildSecurityIncidentEventListener(@NonNull GuildSecurityIncidentEventHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -26,10 +32,9 @@ public final class GuildSecurityIncidentEventListener extends ListenerAdapter {
                 event.getGuild().getName(), event.getGuild().getId()
         );
 
-        Thread.ofVirtual()
-                .name("guild-update-security-incident-detection-event-listener-vthread-", 0)
-                .start(() -> handler.handleGuildUpdateSecurityIncidentDetections(event));
-
+        virtualThreadFactory
+                .newThread(() -> handler.handleGuildUpdateSecurityIncidentDetections(event))
+                .start();
     }
 
     @Override
@@ -38,9 +43,9 @@ public final class GuildSecurityIncidentEventListener extends ListenerAdapter {
                 event.getGuild().getName(), event.getGuild().getId()
         );
 
-        Thread.ofVirtual()
-                .name("guild-update-security-incident-action-event-listener-vthread-", 0)
-                .start(() -> handler.handleGuildUpdateSecurityIncidentActions(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleGuildUpdateSecurityIncidentActions(event))
+                .start();
 
     }
 

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildVoiceEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/guild/GuildVoiceEventListener.java
@@ -1,12 +1,15 @@
 package io.github.eggy03.papertrail.bot.listeners.guild;
 
 import io.github.eggy03.papertrail.bot.handlers.guild.GuildVoiceEventHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.util.concurrent.ThreadFactory;
 
 // this event is not properly logged in the audit logs, hence the usage of JDA's listener is preferred
 // this event is logged in the same channel where the audit log events are logged
@@ -15,10 +18,13 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 public final class GuildVoiceEventListener extends ListenerAdapter {
 
     private final @NonNull GuildVoiceEventHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public GuildVoiceEventListener(@NonNull GuildVoiceEventHandler handler) {
+    public GuildVoiceEventListener(@NonNull GuildVoiceEventHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -27,9 +33,9 @@ public final class GuildVoiceEventListener extends ListenerAdapter {
         log.debug("Received [Event=GuildVoiceUpdate] for [Guild={}, ID={}]",
                 event.getGuild().getName(), event.getGuild().getId()
         );
-        Thread.ofVirtual()
-                .name("guild-voice-update-event-listener-vthread-", 0)
-                .start(() -> handler.handleVoiceUpdateEvent(event));
 
+        virtualThreadFactory
+                .newThread(() -> handler.handleVoiceUpdateEvent(event))
+                .start();
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/message/GuildMessageEventListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/message/GuildMessageEventListener.java
@@ -1,6 +1,7 @@
 package io.github.eggy03.papertrail.bot.listeners.message;
 
 import io.github.eggy03.papertrail.bot.handlers.message.GuildMessageEventHandler;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -9,14 +10,19 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.concurrent.ThreadFactory;
+
 @Singleton
 public final class GuildMessageEventListener extends ListenerAdapter {
 
     private final @NonNull GuildMessageEventHandler handler;
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
 
     @Inject
-    public GuildMessageEventListener(@NonNull GuildMessageEventHandler handler) {
+    public GuildMessageEventListener(@NonNull GuildMessageEventHandler handler, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.handler = handler;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
@@ -31,9 +37,9 @@ public final class GuildMessageEventListener extends ListenerAdapter {
             return;
         }
 
-        Thread.ofVirtual()
-                .name("message-received-event-listener-vthread-", 0)
-                .start(() -> handler.handleMessageReceivedEvent(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleMessageReceivedEvent(event))
+                .start();
     }
 
     @Override
@@ -43,15 +49,15 @@ public final class GuildMessageEventListener extends ListenerAdapter {
             return;
         }
 
-        Thread.ofVirtual()
-                .name("message-update-event-listener-vthread-", 0)
-                .start(() -> handler.handleMessageUpdateEvent(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleMessageUpdateEvent(event))
+                .start();
     }
 
     @Override
     public void onMessageDelete(@NonNull MessageDeleteEvent event) {
-        Thread.ofVirtual()
-                .name("message-delete-event-listener-vthread-", 0)
-                .start(() -> handler.handleMessageDeleteEvent(event));
+        virtualThreadFactory
+                .newThread(() -> handler.handleMessageDeleteEvent(event))
+                .start();
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/misc/ActivityUpdateListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/misc/ActivityUpdateListener.java
@@ -1,6 +1,6 @@
 package io.github.eggy03.papertrail.bot.listeners.misc;
 
-import io.github.eggy03.papertrail.bot.bean.ApplicationInfo;
+import io.github.eggy03.papertrail.bot.about.ApplicationInfo;
 import io.quarkus.runtime.ImageMode;
 import io.quarkus.runtime.LaunchMode;
 import jakarta.inject.Inject;

--- a/src/main/java/io/github/eggy03/papertrail/bot/listeners/misc/SelfKickListener.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/listeners/misc/SelfKickListener.java
@@ -1,5 +1,6 @@
 package io.github.eggy03.papertrail.bot.listeners.misc;
 
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
 import io.github.eggy03.papertrail.sdk.client.MessageLogRegistrationClient;
 import jakarta.inject.Inject;
@@ -8,6 +9,8 @@ import lombok.NonNull;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.util.concurrent.ThreadFactory;
 
 /*
  * This class will have methods that unregister the log channels from the database after the bot has been kicked
@@ -21,22 +24,24 @@ public final class SelfKickListener extends ListenerAdapter {
     @NonNull
     private final MessageLogRegistrationClient messageLogRegistrationClient;
 
+    private final @NonNull
+    @VirtualThreadFactory ThreadFactory virtualThreadFactory;
+
     @Inject
-    public SelfKickListener(@NonNull AuditLogRegistrationClient auditLogRegistrationClient, @NonNull MessageLogRegistrationClient messageLogRegistrationClient) {
+    public SelfKickListener(@NonNull AuditLogRegistrationClient auditLogRegistrationClient, @NonNull MessageLogRegistrationClient messageLogRegistrationClient, @NonNull @VirtualThreadFactory ThreadFactory virtualThreadFactory) {
         this.auditLogRegistrationClient = auditLogRegistrationClient;
         this.messageLogRegistrationClient = messageLogRegistrationClient;
+        this.virtualThreadFactory = virtualThreadFactory;
     }
 
     @Override
     public void onGuildLeave(@NonNull GuildLeaveEvent event) {
         Guild leftGuild = event.getGuild();
 
-        Thread.ofVirtual()
-                .name("self-guild-leave-event-listener-vthread-", 0)
-                .start(() -> {
-                    auditLogRegistrationClient.deleteRegisteredGuild(leftGuild.getId());
-                    messageLogRegistrationClient.deleteRegisteredGuild(leftGuild.getId());
-                });
+        virtualThreadFactory.newThread(() -> {
+            auditLogRegistrationClient.deleteRegisteredGuild(leftGuild.getId());
+            messageLogRegistrationClient.deleteRegisteredGuild(leftGuild.getId());
+        }).start();
 
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/producers/PaperTrailSdkProducer.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/producers/PaperTrailSdkProducer.java
@@ -1,4 +1,4 @@
-package io.github.eggy03.papertrail.bot.bean;
+package io.github.eggy03.papertrail.bot.producers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.eggy03.papertrail.sdk.client.AuditLogRegistrationClient;
@@ -12,13 +12,13 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jetbrains.annotations.Contract;
 
 @ApplicationScoped
-public final class PaperTrailSdkBeanProvider {
+public final class PaperTrailSdkProducer {
 
     private final @NonNull String apiUrl;
     private final @NonNull ObjectMapper objectMapper;
 
     @Inject
-    public PaperTrailSdkBeanProvider(@ConfigProperty(name = "api.url") @NonNull String apiUrl, @NonNull ObjectMapper objectMapper) {
+    public PaperTrailSdkProducer(@ConfigProperty(name = "api.url") @NonNull String apiUrl, @NonNull ObjectMapper objectMapper) {
         this.apiUrl = apiUrl;
         this.objectMapper = objectMapper;
     }

--- a/src/main/java/io/github/eggy03/papertrail/bot/producers/ThreadFactoryProducer.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/producers/ThreadFactoryProducer.java
@@ -1,0 +1,27 @@
+package io.github.eggy03.papertrail.bot.producers;
+
+import io.github.eggy03.papertrail.bot.qualifiers.PlatformThreadFactory;
+import io.github.eggy03.papertrail.bot.qualifiers.VirtualThreadFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import org.jspecify.annotations.NonNull;
+
+import java.util.concurrent.ThreadFactory;
+
+@ApplicationScoped
+public final class ThreadFactoryProducer {
+
+    @Produces
+    @ApplicationScoped
+    @VirtualThreadFactory
+    public @NonNull ThreadFactory virtualThreadFactory() {
+        return Thread.ofVirtual().name("ptrail-virtual-thread-", 0).factory();
+    }
+
+    @Produces
+    @ApplicationScoped
+    @PlatformThreadFactory
+    public @NonNull ThreadFactory platformThreadFactory() {
+        return Thread.ofPlatform().name("ptrail-platform-thread-", 0).factory();
+    }
+}

--- a/src/main/java/io/github/eggy03/papertrail/bot/qualifiers/PlatformThreadFactory.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/qualifiers/PlatformThreadFactory.java
@@ -1,0 +1,14 @@
+package io.github.eggy03.papertrail.bot.qualifiers;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
+public @interface PlatformThreadFactory {
+}

--- a/src/main/java/io/github/eggy03/papertrail/bot/qualifiers/VirtualThreadFactory.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/qualifiers/VirtualThreadFactory.java
@@ -1,0 +1,14 @@
+package io.github.eggy03.papertrail.bot.qualifiers;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
+public @interface VirtualThreadFactory {
+}

--- a/src/main/java/io/github/eggy03/papertrail/bot/utils/DurationUtils.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/utils/DurationUtils.java
@@ -3,12 +3,11 @@ package io.github.eggy03.papertrail.bot.utils;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 
 @UtilityClass
 @Slf4j
@@ -17,7 +16,7 @@ public final class DurationUtils {
     @NonNull
     private static final String FALLBACK_STRING = "N/A";
 
-    public static String formatSeconds(@Nullable Object seconds) {
+    public static @NonNull String formatSeconds(@Nullable Object seconds) {
         if (seconds == null) {
             return FALLBACK_STRING;
         }
@@ -51,7 +50,7 @@ public final class DurationUtils {
 
     }
 
-    public static String formatMinutes(@Nullable Object minutes) {
+    public static @NonNull String formatMinutes(@Nullable Object minutes) {
         if (minutes == null) {
             return FALLBACK_STRING;
         }
@@ -74,25 +73,15 @@ public final class DurationUtils {
 
     }
 
-    public static String isoToLocalTimeCounter(@Nullable Object isoTime) {
+    public static @NonNull String isoToLocalTimeCounter(@Nullable Object isoTime) {
 
-        if (isoTime == null) {
+        if (isoTime == null)
             return FALLBACK_STRING;
-        }
 
-        String isoTimeString = String.valueOf(isoTime);
-        if (isoTimeString.trim().isEmpty()) {
-            return FALLBACK_STRING;
-        }
+        if (isoTime instanceof OffsetDateTime offsetDateTime)
+            return TimeFormat.DATE_TIME_LONG.format(offsetDateTime);
 
-        try {
-            OffsetDateTime odt = OffsetDateTime.parse(isoTimeString, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-            long unixTimestamp = odt.toEpochSecond();
-            return "<t:" + unixTimestamp + ":f>";
-        } catch (DateTimeParseException e) {
-            log.debug("failed to parse ISO_OFFSET_DATE_TIME from value={}", isoTimeString, e);
-            return String.valueOf(isoTime);
-        }
+        return TimeFormat.DATE_TIME_LONG.format(OffsetDateTime.parse(isoTime.toString()));
 
     }
 }

--- a/src/main/java/io/github/eggy03/papertrail/bot/utils/auditlog/ScheduledEventUtils.java
+++ b/src/main/java/io/github/eggy03/papertrail/bot/utils/auditlog/ScheduledEventUtils.java
@@ -5,7 +5,10 @@ import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.ScheduledEvent;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import org.jetbrains.annotations.Nullable;
+
+import java.time.OffsetDateTime;
 
 @UtilityClass
 @Slf4j
@@ -32,5 +35,12 @@ public final class ScheduledEventUtils {
             return FALLBACK_STRING;
 
         return ScheduledEvent.Status.fromKey(eventType).name();
+    }
+
+    // parse ISO date time format to Discord style
+    @NonNull
+    public static String convertISOTimeToDiscordTimeStamp(@Nullable Object isoDateTime) {
+        if (isoDateTime == null) return FALLBACK_STRING;
+        return TimeFormat.DATE_TIME_LONG.format(OffsetDateTime.parse(isoDateTime.toString()));
     }
 }


### PR DESCRIPTION
## **Description**

This PR adds new formatting for Audit Log Changes pertaining to Threads, Scheduled Events and Roles. Additionally a CDI bean containing producer methods for Platform and Virtual Thread factories have also been added. Injection of these factories can be performed via the qualifiers `@VirtualThreadFactory` and `@PlatformThreadFactory`

## **Type of Change**

### New feature
- Provide formatting for `scheduled_start_time` and `scheduled_end_time` in Scheduled Events
- Provide formatting for `icon_hash`  in Role Events
- Provide formatting for `applied_tags`  in Thread Events

### Refactor
- `isoLocalTimeCounter()` in `DurationUtils` now uses `TimeFormat.DATE_TIME_LONG.format()` from JDA's `TimeFormat` instead of using a manual converter to convert ISO Time to Discord format `<t:....f>`
- Listeners now use the injected Virtual Thread Factory provided by the producer method, instead of invoking `Thread.ofVirtual().start(Runnable r)`

### Dependency Updates
- Update Quarkus Platform to 3.37.0

---

## **Tasks for Native Builds**

- [x] New Code Added
    - [x] New Code Tested In Native Build
- [x] Dependencies Updated
    - [x] Dependencies Updates Tested In Native Build
- [x] Reachability Metadata Updated
    - [x] Update Tested In Native Build